### PR TITLE
Implement Menmo end-to-end journey service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+app.db
+frontend/node_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,117 @@
 # Menmo
-menmo.ai
+
+This repository contains an opinionated prototype of **Menmo’s climate grant copilot** with a FastAPI backend and a React front-end. The backend models the end-to-end customer journey described in the Menmo product brief – from the 2 minute eligibility quick scan to the RAG-guided application builder, evidence validation, deadline radar and post-submission insights.
+
+## Backend
+
+The backend service lives in [`backend/`](backend/) and exposes REST APIs for managing user profiles, ingesting grant opportunities and generating AI-assisted matches.
+
+### Features
+
+- **Multi-stage Journey API** – `/journey/*` endpoints cover Quick Scan, Funding Match, Gap-to-Yes planner, Application Builder, Evidence AutoCheck, Deadline Radar, Finalisation, and Post Submission updates.
+- **Rules- + RAG-driven intelligence** – grants include structured rules JSON alongside proprietary notes; the `backend/rag.py` utility retrieves highlighted knowledge snippets (from [`backend/data/documents.json`](backend/data/documents.json)) to ground explanations and AI-generated drafts.
+- **Rich persistence model** – SQLAlchemy models track user profiles, project payloads, stored matches (with reasons/blockers/citations), remediation tasks, application sections, evidence statuses, and deadlines.
+- **Hybrid matching engine** – `backend/matching.py` prefers `sentence-transformers` embeddings but automatically falls back to a deterministic TF-IDF encoder for offline environments.
+- **Comprehensive tests** – Pytest suites assert the full customer journey flow plus low-level matching behaviour.
+
+### Setup
+
+1. Create and activate a Python 3.11 (or newer) virtual environment.
+2. Install dependencies (a local virtual environment is recommended):
+
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+   Optional: install `sentence-transformers` for higher fidelity embeddings (the system falls back to TF-IDF if the model cannot be loaded).
+
+3. Configure the database connection (defaults to `sqlite:///./app.db`). To use PostgreSQL set the `DATABASE_URL` environment variable, e.g.:
+
+   ```bash
+   export DATABASE_URL=postgresql+psycopg2://user:password@localhost:5432/menmo
+   ```
+
+4. Run the API locally (table creation is handled automatically on startup):
+
+   ```bash
+   uvicorn backend.main:app --reload --port 8000
+   ```
+
+5. (Optional) Prime the database with grant programmes by POSTing to `/grants` using the schema documented below or by adapting the payload from `backend/tests/test_api.py::_ingest_sample_grants`.
+
+### Stage endpoints at a glance
+
+| Stage | Endpoint | Purpose |
+|-------|----------|---------|
+| 0/1. Awareness → Quick Scan | `POST /journey/quick-scan` | Evaluates a minimal organisation profile against hard rules and returns Yes/No/Maybe with citations. |
+| 2. Funding Match | `POST /journey/funding-match` | Ingests rich project data, ranks grants (0-100), stores match explanations, and attaches retrieved knowledge chunks. |
+| 3. Gap-to-Yes Planner | `POST /journey/gap-plan`, `PATCH /journey/tasks/{id}` | Converts blockers into tasks with owners/due dates, enabling Kanban-style remediation. |
+| 4. Application Builder | `POST /journey/application-draft` | Generates section drafts with assumptions, citations, and compliance snapshots using the RAG utility. |
+| 5. Evidence AutoCheck | `POST /journey/evidence-check` | Verifies uploaded artefacts against evidence requirements sourced from proprietary notes. |
+| 6. Deadline Radar | `POST /journey/deadlines`, `GET /journey/deadlines/{user_id}` | Syncs official deadlines and internal milestones for notifications. |
+| 7. Finalisation | `POST /journey/finalise` | Provides a readiness report summarising outstanding tasks and evidence gaps. |
+| 8. Post Submission | `POST /journey/post-submission` | Surfaces ongoing grant updates and proprietary intelligence. |
+
+Refer to the tests in [`backend/tests/test_api.py`](backend/tests/test_api.py) for example request payloads spanning all stages.
+
+### Tests
+
+Execute backend tests with:
+
+```bash
+pytest backend/tests
+```
+
+The suite provisions an in-memory SQLite database and walks through the full Menmo journey to ensure every stage remains functional.
+
+## Frontend
+
+The frontend lives in [`frontend/`](frontend/) and was bootstrapped with Vite + React + TypeScript. It consumes the backend APIs to provide user onboarding, grant ingestion and match browsing experiences.
+
+### Setup
+
+1. Install Node.js 18+.
+2. Install dependencies:
+
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+3. Start the development server (proxies API requests to `localhost:8000`):
+
+   ```bash
+   npm run dev
+   ```
+
+4. Build production assets:
+
+   ```bash
+   npm run build
+   ```
+
+Navigate to `http://localhost:3000` to use the app. Create a user profile, ingest grants, then view recommendations on the **Recommended matches** page.
+
+## Running the full stack locally
+
+1. Start the backend (see instructions above).
+2. In a separate terminal, start the frontend dev server.
+3. The Vite proxy will forward `/api` calls to the FastAPI backend. Update `frontend/vite.config.ts` if your backend runs on a different host or port.
+
+## Project structure
+
+```
+backend/
+  db.py             # Database engine/session helpers
+  main.py           # FastAPI application
+  matching.py       # AI-powered grant matching service
+  models.py         # SQLAlchemy ORM models
+  tests/            # Pytest suites for API and matching logic
+frontend/
+  src/              # React source (components, pages and types)
+README.md           # This file
+```
+
+## License
+
+MIT

--- a/backend/data/documents.json
+++ b/backend/data/documents.json
@@ -1,0 +1,52 @@
+{
+  "documents": [
+    {
+      "id": "klimatklivet_rule_alignment",
+      "title": "Klimatklivet Handbook 2023",
+      "content": "Klimatklivet prioritises investments that deliver measurable CO2e reductions within Sweden and are led by municipalities or SMEs registered in the country.",
+      "citation": {
+        "title": "Klimatklivet Handbook 2023",
+        "section": "2.1",
+        "url": "https://www.naturvardsverket.se/klimatklivet"
+      },
+      "grant_slugs": ["klimatklivet"],
+      "proprietary": false
+    },
+    {
+      "id": "klimatklivet_fast_chargers",
+      "title": "Stockholm Municipality EV Guidance",
+      "content": "Stockholm municipality recommends EV fast chargers rated at 150 kW or higher and requires applicants to submit a baseline emissions inventory using the municipal template.",
+      "citation": {
+        "title": "Stockholm EV Infrastructure Memo",
+        "section": "3.4",
+        "source_type": "proprietary"
+      },
+      "grant_slugs": ["klimatklivet"],
+      "proprietary": true
+    },
+    {
+      "id": "horizon_europe_partnerships",
+      "title": "Horizon Europe Mission Climate",
+      "content": "Projects must include international partnerships and clearly articulate cross-border impact pathways aligned with the Horizon Europe Mission on Climate-Neutral and Smart Cities.",
+      "citation": {
+        "title": "Horizon Europe Mission Work Programme",
+        "section": "1.2.5",
+        "url": "https://research-and-innovation.ec.europa.eu"
+      },
+      "grant_slugs": ["horizoneurope"],
+      "proprietary": false
+    },
+    {
+      "id": "green_deal_evidence",
+      "title": "Green Deal Call Guidance",
+      "content": "Applicants should attach supplier quotes and lifecycle analyses demonstrating alignment with EU Green Deal sustainability taxonomy.",
+      "citation": {
+        "title": "EU Green Deal Call X Guidance",
+        "section": "Annex B",
+        "url": "https://funding.ec.europa.eu"
+      },
+      "grant_slugs": ["greendeal"],
+      "proprietary": false
+    }
+  ]
+}

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,42 @@
+"""Database session management for the backend service."""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Generator, Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+connect_args = {}
+if DATABASE_URL.startswith("sqlite"):
+    # Required for SQLite to allow usage in different threads (e.g., FastAPI)
+    connect_args["check_same_thread"] = False
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args, future=True)
+SessionLocal = scoped_session(sessionmaker(bind=engine, autoflush=False, autocommit=False))
+
+
+def get_session() -> Generator:
+    """FastAPI dependency that yields a database session."""
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@contextmanager
+def session_scope() -> Iterator:
+    """Context manager used in scripts/tests to handle a DB session."""
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/journey.py
+++ b/backend/journey.py
@@ -1,0 +1,606 @@
+"""Business logic orchestrating the Menmo customer journey stages."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from sqlalchemy.orm import Session
+
+from .matching import MatchingService, SimpleTfidfEncoder, _cosine_similarity
+from .models import (
+    ApplicationSection,
+    DeadlineMilestone,
+    EvidenceRequirementStatus,
+    Grant,
+    Match,
+    ProjectProfile,
+    QuickScanResult,
+    RemediationTask,
+    UserProfile,
+)
+from .rag import RAGEngine
+
+
+APPLICATION_SECTIONS: List[Dict[str, str]] = [
+    {"key": "summary", "title": "Project Summary"},
+    {"key": "objectives", "title": "Objectives"},
+    {"key": "climate_impact", "title": "Climate Impact"},
+    {"key": "budget", "title": "Budget"},
+    {"key": "risk", "title": "Risk & Mitigation"},
+]
+
+
+@dataclass
+class RuleEvaluation:
+    """Represents the evaluation outcome of a single rule."""
+
+    id: str
+    text: str
+    citation: Mapping[str, Any]
+    passed: bool
+    severity: str
+    category: str
+
+
+def _normalize(value: Optional[str]) -> str:
+    return (value or "").strip().lower()
+
+
+def _coerce_to_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _tokenize_keywords(value: Optional[str]) -> List[str]:
+    encoder = SimpleTfidfEncoder()
+    if not value:
+        return []
+    return encoder._tokenize(value)
+
+
+class JourneyService:
+    """High-level service implementing the Menmo journey stages."""
+
+    def __init__(self, session: Session):
+        self.session = session
+        self.matching_service = MatchingService()
+        self.rag_engine = RAGEngine()
+
+    # ------------------------------------------------------------------
+    # Stage 1 – Quick Scan
+    # ------------------------------------------------------------------
+    def run_quick_scan(
+        self,
+        user: UserProfile,
+        payload: Mapping[str, Any],
+    ) -> List[QuickScanResult]:
+        """Evaluate quick eligibility for all grants and persist results."""
+
+        for field in [
+            "industry",
+            "entity_type",
+            "location",
+            "company_size",
+            "project_type",
+            "budget_min",
+            "budget_max",
+        ]:
+            if field in payload:
+                setattr(user, field, payload[field])
+
+        self.session.query(QuickScanResult).filter_by(user_id=user.id).delete(
+            synchronize_session=False
+        )
+
+        grants = self.session.query(Grant).all()
+        results: List[QuickScanResult] = []
+        payload = dict(payload)
+        for grant in grants:
+            evaluation = self._evaluate_grant_rules(grant, payload)
+            status = self._derive_status(evaluation)
+            reasons = [
+                {
+                    "id": item.id,
+                    "text": item.text,
+                    "citation": item.citation,
+                }
+                for item in evaluation
+                if item.passed and item.category in {"eligibility", "fit"}
+            ]
+            blockers = [
+                {
+                    "id": item.id,
+                    "text": item.text,
+                    "citation": item.citation,
+                }
+                for item in evaluation
+                if not item.passed
+            ]
+            citations = [item.citation for item in evaluation]
+
+            result = QuickScanResult(
+                user=user,
+                grant=grant,
+                status=status,
+                reasons=reasons,
+                blockers=blockers,
+                citations=citations,
+            )
+            self.session.add(result)
+            results.append(result)
+
+        self.session.commit()
+        return results
+
+    # ------------------------------------------------------------------
+    # Stage 2 – Funding Match
+    # ------------------------------------------------------------------
+    def run_funding_match(
+        self,
+        user: UserProfile,
+        project_payload: Mapping[str, Any],
+        top_k: int = 5,
+    ) -> List[Match]:
+        """Rank grants for the richer project payload with explanations."""
+
+        project = ProjectProfile(
+            user=user,
+            description=project_payload.get("project_description", ""),
+            capex=_coerce_to_float(project_payload.get("capex")),
+            opex=_coerce_to_float(project_payload.get("opex")),
+            timeline=project_payload.get("timeline"),
+            co2e_reduction=_coerce_to_float(project_payload.get("co2_reduction")),
+            partners=project_payload.get("partners"),
+        )
+        self.session.add(project)
+        self.session.flush()
+
+        grants = self.session.query(Grant).all()
+        match_inputs: List[str] = []
+        grant_refs: List[Grant] = []
+        eligibility_cache: Dict[int, List[RuleEvaluation]] = {}
+        user_context = {
+            "industry": user.industry,
+            "entity_type": user.entity_type,
+            "location": user.location,
+            "company_size": user.company_size,
+            "project_type": user.project_type,
+            "budget_min": user.budget_min,
+            "budget_max": user.budget_max,
+        }
+        for grant in grants:
+            evaluations = self._evaluate_grant_rules(
+                grant,
+                {**project_payload, **user_context},
+            )
+            eligibility_cache[grant.id] = evaluations
+            match_inputs.append(self._build_grant_document(grant))
+            grant_refs.append(grant)
+
+        user_document = self._build_user_document(user, project)
+        if not match_inputs:
+            return []
+
+        embeddings = self.matching_service._encode(match_inputs + [user_document])
+        if embeddings.size == 0:
+            return []
+        grant_embeddings = embeddings[:-1]
+        user_vector = embeddings[-1].reshape(1, -1)
+        scores = _cosine_similarity(grant_embeddings, user_vector)
+        match_results: List[Match] = []
+        for grant, similarity in zip(grant_refs, scores):
+            evaluations = eligibility_cache.get(grant.id, [])
+            status = self._derive_status(evaluations)
+            fit_reasons = [
+                {
+                    "id": item.id,
+                    "text": item.text,
+                    "citation": item.citation,
+                }
+                for item in evaluations
+                if item.passed and item.category in {"eligibility", "fit"}
+            ]
+            blockers = [
+                {
+                    "id": item.id,
+                    "text": item.text,
+                    "citation": item.citation,
+                }
+                for item in evaluations
+                if not item.passed
+            ]
+
+            rag_results = self.rag_engine.search(
+                query=project_payload.get("project_description", ""),
+                grant_reference=grant,
+                top_k=3,
+            )
+            citations = [chunk for chunk in rag_results]
+
+            match = Match(
+                user=user,
+                grant=grant,
+                score=float(max(0.0, min(1.0, similarity)) * 100.0),
+                reasons=fit_reasons,
+                blockers=blockers,
+                citations=citations,
+                status="eligible" if status != "No" else "blocked",
+                insights={
+                    "max_support": grant.max_support,
+                    "support_unit": grant.support_unit,
+                    "deadline": grant.deadline,
+                },
+            )
+            self.session.add(match)
+            match_results.append(match)
+
+        match_results.sort(key=lambda item: item.score, reverse=True)
+        self.session.commit()
+        return match_results[:top_k]
+
+    # ------------------------------------------------------------------
+    # Stage 3 – Gap-to-Yes Planner
+    # ------------------------------------------------------------------
+    def build_gap_plan(
+        self,
+        match: Match,
+        assignments: Mapping[str, Any],
+        default_owner: Optional[str] = None,
+        default_due_in_days: int = 14,
+    ) -> List[RemediationTask]:
+        tasks: List[RemediationTask] = []
+        due_date = date.today() + timedelta(days=default_due_in_days)
+        for blocker in match.blockers:
+            rule_id = blocker.get("id")
+            task = RemediationTask(
+                match=match,
+                title=blocker.get("text", "Review blocker"),
+                owner=assignments.get(rule_id, default_owner),
+                due_date=due_date,
+                citation=blocker.get("citation", {}),
+                rule_id=rule_id,
+            )
+            self.session.add(task)
+            tasks.append(task)
+        self.session.commit()
+        return tasks
+
+    # ------------------------------------------------------------------
+    # Stage 4 – Application Builder
+    # ------------------------------------------------------------------
+    def generate_application_sections(
+        self,
+        match: Match,
+        requested_sections: Sequence[str] | None = None,
+    ) -> List[ApplicationSection]:
+        grant = match.grant
+        user = match.user
+        project = self.session.query(ProjectProfile).filter_by(user_id=user.id).order_by(ProjectProfile.created_at.desc()).first()
+        if not project:
+            raise ValueError("No project profile available for application drafting")
+
+        sections: List[ApplicationSection] = []
+        selected_sections = (
+            [section for section in APPLICATION_SECTIONS if section["key"] in requested_sections]
+            if requested_sections
+            else APPLICATION_SECTIONS
+        )
+
+        for section_meta in selected_sections:
+            key = section_meta["key"]
+            title = section_meta["title"]
+            query = f"{title} for {grant.title} {project.description}"
+            rag_chunks = self.rag_engine.search(query=query, grant_reference=grant, top_k=3)
+            assumptions = [
+                f"Based on {chunk['citation'].get('title')} section {chunk['citation'].get('section')}"
+                for chunk in rag_chunks
+            ]
+            draft = self._compose_draft_text(section_key=key, grant=grant, project=project, match=match)
+            section = ApplicationSection(
+                match=match,
+                grant=grant,
+                key=key,
+                title=title,
+                draft=draft,
+                assumptions=assumptions,
+                citations=rag_chunks,
+                compliance=self._section_compliance_snapshot(key, grant),
+                status="suggested",
+            )
+            self.session.add(section)
+            sections.append(section)
+
+        self.session.commit()
+        return sections
+
+    # ------------------------------------------------------------------
+    # Stage 5 – Evidence AutoCheck
+    # ------------------------------------------------------------------
+    def evaluate_evidence(
+        self,
+        match: Match,
+        documents: Sequence[Mapping[str, Any]],
+    ) -> List[EvidenceRequirementStatus]:
+        results: List[EvidenceRequirementStatus] = []
+        provided_types = {doc.get("requirement"): doc for doc in documents}
+        for requirement in match.grant.proprietary_notes or []:
+            if requirement.get("category") != "evidence":
+                continue
+            status_value = "compliant" if requirement.get("id") in provided_types else "missing"
+            notes = None
+            if status_value == "missing":
+                notes = f"Upload document fulfilling requirement {requirement.get('id')}"
+            record = EvidenceRequirementStatus(
+                user=match.user,
+                grant=match.grant,
+                requirement=requirement.get("text", "Evidence item"),
+                status=status_value,
+                notes=notes,
+                citation=requirement.get("citation", {}),
+            )
+            self.session.add(record)
+            results.append(record)
+
+        self.session.commit()
+        return results
+
+    # ------------------------------------------------------------------
+    # Stage 6 – Deadline Radar
+    # ------------------------------------------------------------------
+    def sync_deadlines(
+        self,
+        match: Match,
+        milestones: Sequence[Mapping[str, Any]] | None = None,
+    ) -> List[DeadlineMilestone]:
+        milestones = list(milestones or [])
+        results: List[DeadlineMilestone] = []
+        for grant_deadline in match.grant.deadlines or []:
+            due = self._parse_date(grant_deadline.get("due"))
+            if due is None:
+                continue
+            milestone = DeadlineMilestone(
+                user=match.user,
+                grant=match.grant,
+                label=grant_deadline.get("label", "Grant deadline"),
+                due_date=due,
+                is_grant_deadline=True,
+                source=grant_deadline.get("source"),
+            )
+            self.session.add(milestone)
+            results.append(milestone)
+
+        for user_milestone in milestones:
+            due = self._parse_date(user_milestone.get("due"))
+            if due is None:
+                continue
+            milestone = DeadlineMilestone(
+                user=match.user,
+                grant=match.grant,
+                label=user_milestone.get("label", "Milestone"),
+                due_date=due,
+                is_grant_deadline=False,
+                source=user_milestone.get("source"),
+            )
+            self.session.add(milestone)
+            results.append(milestone)
+
+        self.session.commit()
+        return results
+
+    # ------------------------------------------------------------------
+    # Stage 7 – Finalisation & Export readiness snapshot
+    # ------------------------------------------------------------------
+    def generate_finalisation_snapshot(self, match: Match) -> Dict[str, Any]:
+        tasks = [
+            {
+                "id": task.id,
+                "title": task.title,
+                "status": task.status,
+                "due_date": task.due_date.isoformat() if task.due_date else None,
+            }
+            for task in match.tasks
+        ]
+        evidence = [
+            {
+                "requirement": item.requirement,
+                "status": item.status,
+            }
+            for item in match.user.evidence
+            if item.grant_id == match.grant_id
+        ]
+        outstanding_tasks = any(task["status"] != "done" for task in tasks)
+        outstanding_evidence = any(item["status"] != "compliant" for item in evidence)
+        return {
+            "match_id": match.id,
+            "ready_for_export": not (outstanding_tasks or outstanding_evidence),
+            "tasks": tasks,
+            "evidence": evidence,
+        }
+
+    # ------------------------------------------------------------------
+    # Stage 8 – Post submission intelligence
+    # ------------------------------------------------------------------
+    def post_submission_updates(self, match: Match) -> Dict[str, Any]:
+        updates = []
+        for note in match.grant.proprietary_notes or []:
+            if note.get("category") == "update":
+                updates.append(
+                    {
+                        "id": note.get("id"),
+                        "text": note.get("text"),
+                        "citation": note.get("citation"),
+                    }
+                )
+        return {
+            "match_id": match.id,
+            "grant": match.grant.title,
+            "updates": updates,
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _evaluate_grant_rules(
+        self, grant: Grant, payload: Mapping[str, Any]
+    ) -> List[RuleEvaluation]:
+        evaluations: List[RuleEvaluation] = []
+        payload_norm = {key: _normalize(str(value)) for key, value in payload.items() if value is not None}
+        for rule in grant.rules or []:
+            field = rule.get("field")
+            operator = rule.get("operator", "equals")
+            value = rule.get("value")
+            severity = rule.get("severity", "required")
+            category = rule.get("category", "eligibility")
+            passed = self._apply_rule(field, operator, value, payload, payload_norm)
+            evaluations.append(
+                RuleEvaluation(
+                    id=rule.get("id", f"{grant.id}-rule"),
+                    text=rule.get("text", ""),
+                    citation=rule.get("citation", {}),
+                    passed=passed,
+                    severity=severity,
+                    category=category,
+                )
+            )
+        return evaluations
+
+    def _apply_rule(
+        self,
+        field: Optional[str],
+        operator: str,
+        value: Any,
+        payload_raw: Mapping[str, Any],
+        payload_norm: Mapping[str, str],
+    ) -> bool:
+        if field is None:
+            return True
+        raw = payload_raw.get(field)
+        normalized = payload_norm.get(field)
+
+        if operator == "equals":
+            if isinstance(value, str):
+                return normalized == _normalize(value)
+            return raw == value
+        if operator == "in":
+            if raw is None:
+                return False
+            options = {_normalize(str(item)) for item in (value or [])}
+            if isinstance(raw, (list, tuple, set)):
+                return any(_normalize(str(item)) in options for item in raw)
+            return normalized in options
+        if operator == "any":
+            options = {_normalize(str(item)) for item in (value or [])}
+            if isinstance(raw, (list, tuple, set)):
+                return any(_normalize(str(item)) in options for item in raw)
+            tokens = set(_tokenize_keywords(str(raw)))
+            return bool(tokens & options)
+        if operator == "gte":
+            return _coerce_to_float(raw) is not None and _coerce_to_float(raw) >= _coerce_to_float(value)
+        if operator == "lte":
+            return _coerce_to_float(raw) is not None and _coerce_to_float(raw) <= _coerce_to_float(value)
+        if operator == "range":
+            number = _coerce_to_float(raw)
+            if number is None:
+                return False
+            minimum = _coerce_to_float(value.get("min"))
+            maximum = _coerce_to_float(value.get("max"))
+            if minimum is not None and number < minimum:
+                return False
+            if maximum is not None and number > maximum:
+                return False
+            return True
+        if operator == "contains":
+            tokens = set(_tokenize_keywords(str(raw)))
+            targets = {_normalize(str(item)) for item in (value or [])}
+            return bool(tokens & targets)
+        return True
+
+    def _derive_status(self, evaluations: Iterable[RuleEvaluation]) -> str:
+        status = "Yes"
+        for item in evaluations:
+            if item.passed:
+                continue
+            if item.severity == "required":
+                return "No"
+            status = "Maybe"
+        return status
+
+    def _build_user_document(self, user: UserProfile, project: ProjectProfile) -> str:
+        parts = [
+            user.organization or user.name,
+            user.industry or "",
+            user.project_type or "",
+            project.description,
+            project.partners or "",
+        ]
+        return "\n".join(part for part in parts if part)
+
+    def _build_grant_document(self, grant: Grant) -> str:
+        parts = [grant.title, grant.description]
+        for rule in grant.rules or []:
+            parts.append(rule.get("text", ""))
+        for note in grant.proprietary_notes or []:
+            parts.append(note.get("text", ""))
+        return "\n".join(part for part in parts if part)
+
+    def _compose_draft_text(
+        self,
+        section_key: str,
+        grant: Grant,
+        project: ProjectProfile,
+        match: Match,
+    ) -> str:
+        base = f"{grant.title} expects applicants to demonstrate alignment with {grant.description[:120]}"
+        if section_key == "summary":
+            return (
+                f"{project.description} led by {match.user.organization or match.user.name} targets {grant.title}. "
+                f"The initiative invests CAPEX of {project.capex or 'N/A'} and anticipates CO2e reductions of {project.co2e_reduction or 'N/A'} t/yr."
+            )
+        if section_key == "objectives":
+            return (
+                f"Objectives focus on {match.user.focus_areas or match.user.goals or 'decarbonisation'}. "
+                f"Key partners: {project.partners or 'not yet defined'}."
+            )
+        if section_key == "climate_impact":
+            return (
+                f"Projected CO2e reduction: {project.co2e_reduction or 'data pending'} tonnes annually, "
+                f"supporting {grant.title}'s requirement to prioritise high-impact mitigation projects."
+            )
+        if section_key == "budget":
+            return (
+                f"CAPEX: {project.capex or 'n/a'} SEK, OPEX: {project.opex or 'n/a'} SEK with grant support ceiling {grant.max_support or 'unknown'} {grant.support_unit or ''}."
+            )
+        if section_key == "risk":
+            return "Risks include permitting and supply lead-times; mitigation leverages municipal coordination and vetted suppliers."
+        return base
+
+    def _section_compliance_snapshot(self, section_key: str, grant: Grant) -> Dict[str, Any]:
+        compliance_items = []
+        for rule in grant.rules or []:
+            if rule.get("category") == section_key:
+                compliance_items.append(
+                    {
+                        "rule_id": rule.get("id"),
+                        "text": rule.get("text"),
+                        "citation": rule.get("citation"),
+                    }
+                )
+        return {
+            "section": section_key,
+            "rules": compliance_items,
+        }
+
+    def _parse_date(self, value: Any) -> Optional[date]:
+        if not value:
+            return None
+        if isinstance(value, date):
+            return value
+        try:
+            return date.fromisoformat(str(value))
+        except Exception:
+            return None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,534 @@
+"""FastAPI application exposing Menmo's multi-stage customer journey."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from fastapi import Depends, FastAPI, HTTPException, Path
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.orm import Session
+
+from .db import engine, get_session
+from .journey import JourneyService
+from .models import (
+    Base,
+    DeadlineMilestone,
+    Grant,
+    Match,
+    RemediationTask,
+    UserProfile,
+)
+
+app = FastAPI(title="Menmo Journey API", version="0.2.0")
+
+
+# ---------------------------------------------------------------------------
+# Pydantic Schemas
+# ---------------------------------------------------------------------------
+class Citation(BaseModel):
+    title: str
+    section: Optional[str] = None
+    url: Optional[str] = None
+    source_type: Optional[str] = Field(default=None, description="public|proprietary")
+
+
+class RulePayload(BaseModel):
+    id: str
+    text: str
+    field: Optional[str] = None
+    operator: Optional[str] = "equals"
+    value: Any = None
+    severity: Optional[str] = "required"
+    category: Optional[str] = "eligibility"
+    citation: Citation | Dict[str, Any]
+
+
+class ProprietaryNotePayload(BaseModel):
+    id: str
+    category: str
+    text: str
+    citation: Citation | Dict[str, Any]
+
+
+class DeadlinePayload(BaseModel):
+    label: str
+    due: str
+    source: Optional[str] = None
+
+
+class UserCreate(BaseModel):
+    name: str
+    email: str
+    organization: Optional[str] = None
+    focus_areas: Optional[str] = None
+    goals: Optional[str] = None
+    industry: Optional[str] = None
+    entity_type: Optional[str] = None
+    location: Optional[str] = None
+    company_size: Optional[str] = None
+    project_type: Optional[str] = None
+    budget_min: Optional[float] = None
+    budget_max: Optional[float] = None
+
+
+class UserRead(UserCreate):
+    id: int
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GrantCreate(BaseModel):
+    title: str
+    description: str
+    sponsor: Optional[str] = None
+    deadline: Optional[str] = None
+    url: Optional[str] = None
+    jurisdiction: Optional[str] = None
+    entity_types: List[str] = Field(default_factory=list)
+    industries: List[str] = Field(default_factory=list)
+    project_types: List[str] = Field(default_factory=list)
+    budget_min: Optional[float] = None
+    budget_max: Optional[float] = None
+    min_co2_reduction: Optional[float] = None
+    max_support: Optional[float] = None
+    support_unit: Optional[str] = None
+    rules: List[RulePayload] = Field(default_factory=list)
+    proprietary_notes: List[ProprietaryNotePayload] = Field(default_factory=list)
+    deadlines: List[DeadlinePayload] = Field(default_factory=list)
+
+
+class GrantRead(GrantCreate):
+    id: int
+    model_config = ConfigDict(from_attributes=True)
+
+
+class QuickScanRequest(BaseModel):
+    user_id: int
+    industry: Optional[str] = None
+    entity_type: Optional[str] = None
+    location: Optional[str] = None
+    company_size: Optional[str] = None
+    project_type: Optional[str] = None
+    budget_min: Optional[float] = None
+    budget_max: Optional[float] = None
+
+
+class QuickScanItem(BaseModel):
+    grant_id: int
+    grant_title: str
+    status: str
+    reasons: List[Dict[str, Any]]
+    blockers: List[Dict[str, Any]]
+    citations: List[Dict[str, Any]]
+
+
+class FundingMatchRequest(BaseModel):
+    user_id: int
+    project_description: str
+    capex: Optional[float] = None
+    opex: Optional[float] = None
+    timeline: Optional[str] = None
+    co2_reduction: Optional[float] = None
+    partners: Optional[str] = None
+    top_k: int = 5
+
+
+class MatchResponse(BaseModel):
+    id: int
+    grant: GrantRead
+    score: float
+    status: str
+    reasons: List[Dict[str, Any]]
+    blockers: List[Dict[str, Any]]
+    citations: List[Dict[str, Any]]
+    insights: Dict[str, Any]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GapPlanRequest(BaseModel):
+    match_id: int
+    assignments: Dict[str, str] = Field(default_factory=dict)
+    default_owner: Optional[str] = None
+    default_due_in_days: int = 14
+
+
+class TaskRead(BaseModel):
+    id: int
+    title: str
+    status: str
+    owner: Optional[str]
+    due_date: Optional[str]
+    citation: Dict[str, Any]
+    rule_id: Optional[str]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TaskUpdate(BaseModel):
+    status: Optional[str] = None
+    owner: Optional[str] = None
+
+
+class ApplicationDraftRequest(BaseModel):
+    match_id: int
+    sections: Optional[List[str]] = None
+
+
+class ApplicationSectionRead(BaseModel):
+    id: int
+    key: str
+    title: str
+    draft: str
+    assumptions: List[str]
+    citations: List[Dict[str, Any]]
+    compliance: Dict[str, Any]
+    status: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class EvidenceDocument(BaseModel):
+    requirement: str
+    file_name: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class EvidenceCheckRequest(BaseModel):
+    match_id: int
+    documents: List[EvidenceDocument] = Field(default_factory=list)
+
+
+class EvidenceRead(BaseModel):
+    id: int
+    requirement: str
+    status: str
+    notes: Optional[str]
+    citation: Dict[str, Any]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DeadlineSyncRequest(BaseModel):
+    match_id: int
+    milestones: Optional[List[Dict[str, Any]]] = None
+
+
+class DeadlineRead(BaseModel):
+    id: int
+    label: str
+    due_date: date
+    is_grant_deadline: bool
+    source: Optional[str]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FinalisationRequest(BaseModel):
+    match_id: int
+
+
+class FinalisationResponse(BaseModel):
+    match_id: int
+    ready_for_export: bool
+    tasks: List[Dict[str, Any]]
+    evidence: List[Dict[str, Any]]
+
+
+class PostSubmissionRequest(BaseModel):
+    match_id: int
+
+
+class PostSubmissionResponse(BaseModel):
+    match_id: int
+    grant: str
+    updates: List[Dict[str, Any]]
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle Hooks
+# ---------------------------------------------------------------------------
+@app.on_event("startup")
+def on_startup() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+# ---------------------------------------------------------------------------
+# User & Grant management
+# ---------------------------------------------------------------------------
+@app.post("/users", response_model=UserRead, status_code=201)
+def create_user(user_in: UserCreate, session: Session = Depends(get_session)) -> UserRead:
+    existing = session.query(UserProfile).filter(UserProfile.email == user_in.email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="User with this email already exists")
+
+    user = UserProfile(**user_in.model_dump())
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@app.get("/users/{user_id}", response_model=UserRead)
+def get_user(user_id: int, session: Session = Depends(get_session)) -> UserRead:
+    user = session.query(UserProfile).filter(UserProfile.id == user_id).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@app.post("/grants", response_model=List[GrantRead], status_code=201)
+def ingest_grants(
+    grants: Sequence[GrantCreate], session: Session = Depends(get_session)
+) -> List[GrantRead]:
+    grant_models = []
+    for grant_payload in grants:
+        grant = Grant(**grant_payload.model_dump())
+        grant_models.append(grant)
+        session.add(grant)
+    session.commit()
+    for grant in grant_models:
+        session.refresh(grant)
+    return grant_models
+
+
+@app.get("/grants", response_model=List[GrantRead])
+def list_grants(session: Session = Depends(get_session)) -> List[GrantRead]:
+    return session.query(Grant).order_by(Grant.created_at.desc()).all()
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 – Quick Scan
+# ---------------------------------------------------------------------------
+@app.post("/journey/quick-scan", response_model=List[QuickScanItem])
+def quick_scan(
+    payload: QuickScanRequest, session: Session = Depends(get_session)
+) -> List[QuickScanItem]:
+    user = _get_user(session, payload.user_id)
+    service = JourneyService(session)
+    results = service.run_quick_scan(user=user, payload=payload.model_dump())
+    response: List[QuickScanItem] = []
+    for result in results:
+        response.append(
+            QuickScanItem(
+                grant_id=result.grant_id,
+                grant_title=result.grant.title,
+                status=result.status,
+                reasons=result.reasons,
+                blockers=result.blockers,
+                citations=result.citations,
+            )
+        )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 – Funding Match
+# ---------------------------------------------------------------------------
+@app.post("/journey/funding-match", response_model=List[MatchResponse])
+def funding_match(
+    payload: FundingMatchRequest, session: Session = Depends(get_session)
+) -> List[MatchResponse]:
+    user = _get_user(session, payload.user_id)
+    service = JourneyService(session)
+    matches = service.run_funding_match(
+        user=user,
+        project_payload=payload.model_dump(),
+        top_k=payload.top_k,
+    )
+    response: List[MatchResponse] = []
+    for match in matches:
+        response.append(
+            MatchResponse(
+                id=match.id,
+                grant=match.grant,
+                score=match.score,
+                status=match.status,
+                reasons=match.reasons,
+                blockers=match.blockers,
+                citations=match.citations,
+                insights=match.insights,
+            )
+        )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 – Gap-to-Yes planner
+# ---------------------------------------------------------------------------
+@app.post("/journey/gap-plan", response_model=List[TaskRead])
+def gap_plan(
+    payload: GapPlanRequest, session: Session = Depends(get_session)
+) -> List[TaskRead]:
+    match = _get_match(session, payload.match_id)
+    service = JourneyService(session)
+    tasks = service.build_gap_plan(
+        match=match,
+        assignments=payload.assignments,
+        default_owner=payload.default_owner,
+        default_due_in_days=payload.default_due_in_days,
+    )
+    return [
+        TaskRead(
+            id=task.id,
+            title=task.title,
+            status=task.status,
+            owner=task.owner,
+            due_date=task.due_date.isoformat() if task.due_date else None,
+            citation=task.citation,
+            rule_id=task.rule_id,
+        )
+        for task in tasks
+    ]
+
+
+@app.patch("/journey/tasks/{task_id}", response_model=TaskRead)
+def update_task(
+    payload: TaskUpdate,
+    task_id: int = Path(..., description="Task identifier"),
+    session: Session = Depends(get_session),
+) -> TaskRead:
+    task = session.query(RemediationTask).filter_by(id=task_id).first()
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if payload.status is not None:
+        task.status = payload.status
+    if payload.owner is not None:
+        task.owner = payload.owner
+    session.commit()
+    session.refresh(task)
+    return TaskRead(
+        id=task.id,
+        title=task.title,
+        status=task.status,
+        owner=task.owner,
+        due_date=task.due_date.isoformat() if task.due_date else None,
+        citation=task.citation,
+        rule_id=task.rule_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 4 – Application Builder
+# ---------------------------------------------------------------------------
+@app.post("/journey/application-draft", response_model=List[ApplicationSectionRead])
+def application_draft(
+    payload: ApplicationDraftRequest, session: Session = Depends(get_session)
+) -> List[ApplicationSectionRead]:
+    match = _get_match(session, payload.match_id)
+    service = JourneyService(session)
+    sections = service.generate_application_sections(
+        match=match,
+        requested_sections=payload.sections,
+    )
+    return [
+        ApplicationSectionRead(
+            id=section.id,
+            key=section.key,
+            title=section.title,
+            draft=section.draft,
+            assumptions=section.assumptions,
+            citations=section.citations,
+            compliance=section.compliance,
+            status=section.status,
+        )
+        for section in sections
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Stage 5 – Evidence AutoCheck
+# ---------------------------------------------------------------------------
+@app.post("/journey/evidence-check", response_model=List[EvidenceRead])
+def evidence_check(
+    payload: EvidenceCheckRequest, session: Session = Depends(get_session)
+) -> List[EvidenceRead]:
+    match = _get_match(session, payload.match_id)
+    service = JourneyService(session)
+    records = service.evaluate_evidence(match=match, documents=[doc.model_dump() for doc in payload.documents])
+    return [
+        EvidenceRead(
+            id=record.id,
+            requirement=record.requirement,
+            status=record.status,
+            notes=record.notes,
+            citation=record.citation,
+        )
+        for record in records
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Stage 6 – Deadline Radar
+# ---------------------------------------------------------------------------
+@app.post("/journey/deadlines", response_model=List[DeadlineRead])
+def sync_deadlines(
+    payload: DeadlineSyncRequest, session: Session = Depends(get_session)
+) -> List[DeadlineRead]:
+    match = _get_match(session, payload.match_id)
+    service = JourneyService(session)
+    deadlines = service.sync_deadlines(match=match, milestones=payload.milestones)
+    return [
+        DeadlineRead(
+            id=item.id,
+            label=item.label,
+            due_date=item.due_date,
+            is_grant_deadline=item.is_grant_deadline,
+            source=item.source,
+        )
+        for item in deadlines
+    ]
+
+
+@app.get("/journey/deadlines/{user_id}", response_model=List[DeadlineRead])
+def list_deadlines(user_id: int, session: Session = Depends(get_session)) -> List[DeadlineRead]:
+    _get_user(session, user_id)
+    deadlines = (
+        session.query(DeadlineMilestone)
+        .filter(DeadlineMilestone.user_id == user_id)
+        .order_by(DeadlineMilestone.due_date)
+        .all()
+    )
+    return deadlines
+
+
+# ---------------------------------------------------------------------------
+# Stage 7 – Finalisation snapshot
+# ---------------------------------------------------------------------------
+@app.post("/journey/finalise", response_model=FinalisationResponse)
+def finalise(
+    payload: FinalisationRequest, session: Session = Depends(get_session)
+) -> FinalisationResponse:
+    match = _get_match(session, payload.match_id)
+    service = JourneyService(session)
+    snapshot = service.generate_finalisation_snapshot(match)
+    return FinalisationResponse(**snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Stage 8 – Post submission updates
+# ---------------------------------------------------------------------------
+@app.post("/journey/post-submission", response_model=PostSubmissionResponse)
+def post_submission(
+    payload: PostSubmissionRequest, session: Session = Depends(get_session)
+) -> PostSubmissionResponse:
+    match = _get_match(session, payload.match_id)
+    service = JourneyService(session)
+    data = service.post_submission_updates(match)
+    return PostSubmissionResponse(**data)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _get_user(session: Session, user_id: int) -> UserProfile:
+    user = session.query(UserProfile).filter(UserProfile.id == user_id).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+def _get_match(session: Session, match_id: int) -> Match:
+    match = session.query(Match).filter(Match.id == match_id).first()
+    if match is None:
+        raise HTTPException(status_code=404, detail="Match not found")
+    return match

--- a/backend/matching.py
+++ b/backend/matching.py
@@ -1,0 +1,173 @@
+"""Matching logic that ranks grants for a user profile."""
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+import numpy as np
+from sqlalchemy.orm import Session
+
+from .models import Grant, Match, UserProfile
+
+try:  # pragma: no cover - optional dependency
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover - fallback to lightweight encoder
+    SentenceTransformer = None  # type: ignore
+
+
+def _cosine_similarity(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Compute cosine similarity between matrix *a* and vector *b*."""
+
+    if a.size == 0 or b.size == 0:
+        return np.zeros(a.shape[0])
+    a_norm = np.linalg.norm(a, axis=1, keepdims=True)
+    b_norm = np.linalg.norm(b, axis=1, keepdims=True)
+    a_norm[a_norm == 0] = 1
+    b_norm[b_norm == 0] = 1
+    return (a @ b.T).flatten() / (a_norm.flatten() * b_norm.flatten()[0])
+
+
+class SimpleTfidfEncoder:
+    """A lightweight TF-IDF encoder used when transformers are unavailable."""
+
+    TOKEN_PATTERN = re.compile(r"[A-Za-z0-9']+")
+
+    def __init__(self) -> None:
+        self.vocabulary_: dict[str, int] | None = None
+        self.idf_: dict[str, float] | None = None
+
+    def _tokenize(self, text: str) -> List[str]:
+        return [token.lower() for token in self.TOKEN_PATTERN.findall(text)]
+
+    def _fit(self, tokenized_docs: Sequence[List[str]]) -> None:
+        doc_freq: Counter[str] = Counter()
+        for tokens in tokenized_docs:
+            doc_freq.update(set(tokens))
+
+        vocab = {token: idx for idx, token in enumerate(sorted(doc_freq))}
+        num_docs = len(tokenized_docs)
+        idf = {token: math.log((1 + num_docs) / (1 + freq)) + 1 for token, freq in doc_freq.items()}
+
+        self.vocabulary_ = vocab
+        self.idf_ = idf
+
+    def fit_transform(self, docs: Sequence[str]) -> np.ndarray:
+        tokenized = [self._tokenize(doc) for doc in docs]
+        self._fit(tokenized)
+        return self._transform(tokenized)
+
+    def transform(self, docs: Sequence[str]) -> np.ndarray:
+        if self.vocabulary_ is None or self.idf_ is None:
+            raise RuntimeError("Vectorizer has not been fitted")
+        tokenized = [self._tokenize(doc) for doc in docs]
+        return self._transform(tokenized)
+
+    def _transform(self, tokenized_docs: Sequence[List[str]]) -> np.ndarray:
+        vocab = self.vocabulary_ or {}
+        idf = self.idf_ or {}
+        matrix = np.zeros((len(tokenized_docs), len(vocab)), dtype=float)
+        for row, tokens in enumerate(tokenized_docs):
+            if not tokens:
+                continue
+            counts = Counter(tokens)
+            length = float(sum(counts.values()))
+            for token, count in counts.items():
+                idx = vocab.get(token)
+                if idx is None:
+                    continue
+                matrix[row, idx] = (count / length) * idf.get(token, 0.0)
+        return matrix
+
+
+@dataclass
+class RankedMatch:
+    """Represents a ranked match result."""
+
+    grant: Grant
+    score: float
+
+
+class MatchingService:
+    """Service encapsulating the matching algorithm."""
+
+    def __init__(self, model_name: str | None = None) -> None:
+        self._model_name = model_name or "all-MiniLM-L6-v2"
+        self._transformer = None
+        if SentenceTransformer is not None:
+            try:
+                self._transformer = SentenceTransformer(self._model_name)
+            except Exception:
+                # Downloading models may fail in restricted environments; fallback to TF-IDF.
+                self._transformer = None
+
+    def _encode(self, documents: Sequence[str]) -> np.ndarray:
+        """Encode documents into dense vectors."""
+
+        if not documents:
+            return np.empty((0, 0))
+
+        if self._transformer is not None:
+            embeddings = self._transformer.encode(list(documents))
+            return np.asarray(embeddings, dtype=float)
+
+        vectorizer = SimpleTfidfEncoder()
+        return vectorizer.fit_transform(documents)
+
+    def _build_user_document(self, user: UserProfile) -> str:
+        parts = [user.name, user.organization or "", user.focus_areas or "", user.goals or ""]
+        return "\n".join(part for part in parts if part)
+
+    def _build_grant_document(self, grant: Grant) -> str:
+        parts = [grant.title, grant.description, grant.sponsor or "", grant.deadline or ""]
+        return "\n".join(part for part in parts if part)
+
+    def generate_matches(
+        self,
+        session: Session,
+        user: UserProfile,
+        grants: Iterable[Grant] | None = None,
+        top_k: int = 5,
+    ) -> List[RankedMatch]:
+        """Return ranked matches for a user."""
+
+        grants_list = list(grants if grants is not None else session.query(Grant).all())
+        if not grants_list:
+            return []
+
+        user_document = self._build_user_document(user)
+        grant_documents = [self._build_grant_document(grant) for grant in grants_list]
+
+        documents = grant_documents + [user_document]
+        embeddings = self._encode(documents)
+        if embeddings.size == 0:
+            return []
+
+        grant_vectors = embeddings[:-1]
+        user_vector = embeddings[-1].reshape(1, -1)
+        similarities = _cosine_similarity(grant_vectors, user_vector)
+
+        ranked: List[RankedMatch] = []
+        for grant, score in zip(grants_list, similarities):
+            ranked.append(RankedMatch(grant=grant, score=float(score)))
+
+        ranked.sort(key=lambda item: item.score, reverse=True)
+        top_matches = ranked[:top_k]
+
+        # Persist matches for traceability.
+        for item in top_matches:
+            match = Match(user_id=user.id, grant_id=item.grant.id, score=item.score)
+            session.merge(match)
+        session.commit()
+
+        return top_matches
+
+
+def generate_matches(session: Session, user_id: int, top_k: int = 5) -> List[RankedMatch]:
+    """Convenience wrapper to generate matches for a user id."""
+
+    user = session.query(UserProfile).filter(UserProfile.id == user_id).one()
+    service = MatchingService()
+    return service.generate_matches(session=session, user=user, top_k=top_k)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,262 @@
+"""SQLAlchemy models representing backend persistence layer."""
+from __future__ import annotations
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Float,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class TimestampedModel:
+    """Mixin providing created/updated timestamps."""
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class UserProfile(TimestampedModel, Base):
+    """Represents a user profile stored in the database."""
+
+    __tablename__ = "user_profiles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    email = Column(String(255), nullable=False, unique=True, index=True)
+    organization = Column(String(255), nullable=True)
+    focus_areas = Column(Text, nullable=True)
+    goals = Column(Text, nullable=True)
+    industry = Column(String(100), nullable=True)
+    entity_type = Column(String(100), nullable=True)
+    location = Column(String(255), nullable=True)
+    company_size = Column(String(100), nullable=True)
+    project_type = Column(String(255), nullable=True)
+    budget_min = Column(Float, nullable=True)
+    budget_max = Column(Float, nullable=True)
+
+    matches = relationship("Match", back_populates="user", cascade="all, delete-orphan")
+    projects = relationship(
+        "ProjectProfile", back_populates="user", cascade="all, delete-orphan"
+    )
+    quick_scans = relationship(
+        "QuickScanResult", back_populates="user", cascade="all, delete-orphan"
+    )
+    evidence = relationship(
+        "EvidenceRequirementStatus",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+    deadlines = relationship(
+        "DeadlineMilestone",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
+
+class Grant(TimestampedModel, Base):
+    """Represents an available grant."""
+
+    __tablename__ = "grants"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(255), nullable=False)
+    description = Column(Text, nullable=False)
+    sponsor = Column(String(255), nullable=True)
+    deadline = Column(String(100), nullable=True)
+    url = Column(String(512), nullable=True)
+    jurisdiction = Column(String(255), nullable=True)
+    entity_types = Column(JSON, nullable=False, default=list)
+    industries = Column(JSON, nullable=False, default=list)
+    project_types = Column(JSON, nullable=False, default=list)
+    budget_min = Column(Float, nullable=True)
+    budget_max = Column(Float, nullable=True)
+    min_co2_reduction = Column(Float, nullable=True)
+    max_support = Column(Float, nullable=True)
+    support_unit = Column(String(50), nullable=True)
+    rules = Column(JSON, nullable=False, default=list)
+    proprietary_notes = Column(JSON, nullable=False, default=list)
+    deadlines = Column(JSON, nullable=False, default=list)
+
+    matches = relationship("Match", back_populates="grant", cascade="all, delete-orphan")
+    evidence = relationship(
+        "EvidenceRequirementStatus",
+        back_populates="grant",
+        cascade="all, delete-orphan",
+    )
+    application_sections = relationship(
+        "ApplicationSection",
+        back_populates="grant",
+        cascade="all, delete-orphan",
+    )
+    deadlines_config = relationship(
+        "DeadlineMilestone",
+        back_populates="grant",
+        cascade="all, delete-orphan",
+    )
+
+
+class Match(TimestampedModel, Base):
+    """Represents a stored match score between a user and a grant."""
+
+    __tablename__ = "matches"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, ForeignKey("user_profiles.id", ondelete="CASCADE"), nullable=False
+    )
+    grant_id = Column(
+        Integer, ForeignKey("grants.id", ondelete="CASCADE"), nullable=False
+    )
+    score = Column(Float, nullable=False)
+    reasons = Column(JSON, nullable=False, default=list)
+    blockers = Column(JSON, nullable=False, default=list)
+    citations = Column(JSON, nullable=False, default=list)
+    status = Column(String(50), nullable=False, default="pending")
+    insights = Column(JSON, nullable=False, default=dict)
+
+    user = relationship("UserProfile", back_populates="matches")
+    grant = relationship("Grant", back_populates="matches")
+    tasks = relationship(
+        "RemediationTask", back_populates="match", cascade="all, delete-orphan"
+    )
+    application_sections = relationship(
+        "ApplicationSection",
+        back_populates="match",
+        cascade="all, delete-orphan",
+    )
+
+
+class ProjectProfile(TimestampedModel, Base):
+    """Captures the richer project description used during deep matching."""
+
+    __tablename__ = "project_profiles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, ForeignKey("user_profiles.id", ondelete="CASCADE"), nullable=False
+    )
+    description = Column(Text, nullable=False)
+    capex = Column(Float, nullable=True)
+    opex = Column(Float, nullable=True)
+    timeline = Column(String(255), nullable=True)
+    co2e_reduction = Column(Float, nullable=True)
+    partners = Column(Text, nullable=True)
+
+    user = relationship("UserProfile", back_populates="projects")
+
+
+class QuickScanResult(TimestampedModel, Base):
+    """Stores the outcome of the eligibility quick scan for traceability."""
+
+    __tablename__ = "quick_scan_results"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, ForeignKey("user_profiles.id", ondelete="CASCADE"), nullable=False
+    )
+    grant_id = Column(
+        Integer, ForeignKey("grants.id", ondelete="CASCADE"), nullable=False
+    )
+    status = Column(String(20), nullable=False)
+    reasons = Column(JSON, nullable=False, default=list)
+    blockers = Column(JSON, nullable=False, default=list)
+    citations = Column(JSON, nullable=False, default=list)
+
+    user = relationship("UserProfile", back_populates="quick_scans")
+    grant = relationship("Grant")
+
+
+class RemediationTask(TimestampedModel, Base):
+    """Represents a blocker converted into an actionable task."""
+
+    __tablename__ = "remediation_tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    match_id = Column(
+        Integer, ForeignKey("matches.id", ondelete="CASCADE"), nullable=False
+    )
+    title = Column(String(255), nullable=False)
+    status = Column(String(50), nullable=False, default="todo")
+    owner = Column(String(255), nullable=True)
+    due_date = Column(Date, nullable=True)
+    citation = Column(JSON, nullable=False, default=dict)
+    rule_id = Column(String(100), nullable=True)
+
+    match = relationship("Match", back_populates="tasks")
+
+
+class ApplicationSection(TimestampedModel, Base):
+    """Draft content for each section of the application builder."""
+
+    __tablename__ = "application_sections"
+
+    id = Column(Integer, primary_key=True, index=True)
+    match_id = Column(
+        Integer, ForeignKey("matches.id", ondelete="CASCADE"), nullable=False
+    )
+    grant_id = Column(
+        Integer, ForeignKey("grants.id", ondelete="CASCADE"), nullable=False
+    )
+    key = Column(String(100), nullable=False)
+    title = Column(String(255), nullable=False)
+    draft = Column(Text, nullable=False)
+    assumptions = Column(JSON, nullable=False, default=list)
+    citations = Column(JSON, nullable=False, default=list)
+    compliance = Column(JSON, nullable=False, default=dict)
+    status = Column(String(50), nullable=False, default="suggested")
+
+    match = relationship("Match", back_populates="application_sections")
+    grant = relationship("Grant", back_populates="application_sections")
+
+
+class EvidenceRequirementStatus(TimestampedModel, Base):
+    """Tracks evidence items supplied against requirements."""
+
+    __tablename__ = "evidence_requirements"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, ForeignKey("user_profiles.id", ondelete="CASCADE"), nullable=False
+    )
+    grant_id = Column(
+        Integer, ForeignKey("grants.id", ondelete="CASCADE"), nullable=False
+    )
+    requirement = Column(String(255), nullable=False)
+    status = Column(String(50), nullable=False, default="missing")
+    notes = Column(Text, nullable=True)
+    citation = Column(JSON, nullable=False, default=dict)
+
+    user = relationship("UserProfile", back_populates="evidence")
+    grant = relationship("Grant", back_populates="evidence")
+
+
+class DeadlineMilestone(TimestampedModel, Base):
+    """Stores grant deadlines and user-defined milestones for reminders."""
+
+    __tablename__ = "deadline_milestones"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, ForeignKey("user_profiles.id", ondelete="CASCADE"), nullable=False
+    )
+    grant_id = Column(
+        Integer, ForeignKey("grants.id", ondelete="CASCADE"), nullable=False
+    )
+    label = Column(String(255), nullable=False)
+    due_date = Column(Date, nullable=False)
+    is_grant_deadline = Column(Boolean, nullable=False, default=False)
+    source = Column(String(255), nullable=True)
+
+    user = relationship("UserProfile", back_populates="deadlines")
+    grant = relationship("Grant", back_populates="deadlines_config")

--- a/backend/rag.py
+++ b/backend/rag.py
@@ -1,0 +1,100 @@
+"""Simple Retrieval-Augmented Generation utilities for Menmo."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import numpy as np
+
+from .matching import SimpleTfidfEncoder, _cosine_similarity
+from .models import Grant
+
+
+@dataclass
+class DocumentChunk:
+    """Represents a retrievable knowledge paragraph."""
+
+    id: str
+    title: str
+    content: str
+    citation: Dict[str, Any]
+    grant_slugs: Sequence[str]
+    proprietary: bool = False
+
+
+def _load_documents() -> List[DocumentChunk]:
+    data_path = Path(__file__).parent / "data" / "documents.json"
+    if not data_path.exists():
+        return []
+    data = json.loads(data_path.read_text())
+    documents = []
+    for item in data.get("documents", []):
+        documents.append(
+            DocumentChunk(
+                id=item.get("id", "doc"),
+                title=item.get("title", "Document"),
+                content=item.get("content", ""),
+                citation=item.get("citation", {}),
+                grant_slugs=item.get("grant_slugs", []),
+                proprietary=bool(item.get("proprietary", False)),
+            )
+        )
+    return documents
+
+
+class RAGEngine:
+    """Small-footprint retrieval engine for contextual grounding."""
+
+    def __init__(self, documents: Optional[Sequence[DocumentChunk]] = None) -> None:
+        self._documents: List[DocumentChunk] = list(documents or _load_documents())
+        self._encoder = SimpleTfidfEncoder()
+        self._matrix: Optional[np.ndarray] = None
+        if self._documents:
+            self._matrix = self._encoder.fit_transform([doc.content for doc in self._documents])
+
+    def search(
+        self,
+        query: str,
+        grant_reference: Optional[Grant] = None,
+        top_k: int = 3,
+    ) -> List[Dict[str, Any]]:
+        if not query or not self._documents:
+            return []
+        indices = list(range(len(self._documents)))
+        if grant_reference is not None and grant_reference.url:
+            slug = self._to_slug(grant_reference.title)
+            indices = [
+                idx
+                for idx, doc in enumerate(self._documents)
+                if not doc.grant_slugs or slug in doc.grant_slugs
+            ]
+        if not indices:
+            return []
+        matrix = self._matrix[indices] if self._matrix is not None else None
+        if matrix is None:
+            return []
+        query_vec = self._encoder.transform([query])
+        scores = _cosine_similarity(matrix, query_vec)
+        paired = [
+            (self._documents[idx], float(score))
+            for idx, score in zip(indices, scores)
+        ]
+        paired.sort(key=lambda item: item[1], reverse=True)
+        results = []
+        for document, score in paired[:top_k]:
+            results.append(
+                {
+                    "id": document.id,
+                    "title": document.title,
+                    "content": document.content,
+                    "citation": document.citation,
+                    "proprietary": document.proprietary,
+                    "score": score,
+                }
+            )
+        return results
+
+    def _to_slug(self, value: str) -> str:
+        return "".join(ch.lower() for ch in value if ch.isalnum())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+sqlalchemy
+pydantic
+pytest
+httpx
+numpy

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+
+from typing import Generator, List
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.db import get_session
+from backend.main import app
+from backend.models import Base
+
+
+@pytest.fixture()
+def session() -> Generator[Session, None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = TestingSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(session: Session) -> Generator[TestClient, None, None]:
+    def override_get_session() -> Generator[Session, None, None]:
+        try:
+            yield session
+        finally:
+            session.rollback()
+
+    app.dependency_overrides[get_session] = override_get_session
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def _ingest_sample_grants(client: TestClient) -> List[int]:
+    payload = [
+        {
+            "title": "Klimatklivet",
+            "description": "Support for Swedish climate mitigation investments such as EV charging.",
+            "deadline": "2024-11-30",
+            "url": "https://www.naturvardsverket.se/klimatklivet",
+            "jurisdiction": "Sweden",
+            "entity_types": ["SME", "Municipality"],
+            "industries": ["transport", "energy"],
+            "project_types": ["ev charging", "energy efficiency"],
+            "budget_min": 50000,
+            "budget_max": 5000000,
+            "min_co2_reduction": 50,
+            "max_support": 700000,
+            "support_unit": "SEK",
+            "rules": [
+                {
+                    "id": "KLIM-ELIG-ENTITY",
+                    "text": "Applicants must be SMEs or municipalities registered in Sweden.",
+                    "field": "entity_type",
+                    "operator": "in",
+                    "value": ["sme", "municipality"],
+                    "severity": "required",
+                    "category": "eligibility",
+                    "citation": {
+                        "title": "Klimatklivet Handbook 2023",
+                        "section": "2.1",
+                    },
+                },
+                {
+                    "id": "KLIM-ELIG-LOC",
+                    "text": "Projects must be executed in Sweden.",
+                    "field": "location",
+                    "operator": "equals",
+                    "value": "Sweden",
+                    "severity": "required",
+                    "category": "eligibility",
+                    "citation": {
+                        "title": "Klimatklivet Handbook 2023",
+                        "section": "1.1",
+                    },
+                },
+                {
+                    "id": "KLIM-BUDGET",
+                    "text": "Eligible budget between 50k and 5M SEK.",
+                    "field": "budget_min",
+                    "operator": "range",
+                    "value": {"min": 50000, "max": 5000000},
+                    "severity": "preferred",
+                    "category": "fit",
+                    "citation": {
+                        "title": "Klimatklivet Budget Guidance",
+                        "section": "4.2",
+                    },
+                },
+                {
+                    "id": "KLIM-PROJECT",
+                    "text": "EV fast chargers of at least 150 kW are prioritised.",
+                    "field": "project_description",
+                    "operator": "contains",
+                    "value": ["charger", "fast"],
+                    "severity": "preferred",
+                    "category": "fit",
+                    "citation": {
+                        "title": "Stockholm EV Infrastructure Memo",
+                        "section": "3.4",
+                        "source_type": "proprietary",
+                    },
+                },
+            ],
+            "proprietary_notes": [
+                {
+                    "id": "KLIM-EVID-BASELINE",
+                    "category": "evidence",
+                    "text": "Submit baseline CO2 inventory using Stockholm municipality template.",
+                    "citation": {
+                        "title": "Stockholm EV Infrastructure Memo",
+                        "section": "3.4",
+                        "source_type": "proprietary",
+                    },
+                },
+                {
+                    "id": "KLIM-UPDATE-2024",
+                    "category": "update",
+                    "text": "Municipal co-funding requirement expected to increase in 2025.",
+                    "citation": {
+                        "title": "Municipal Partner Brief",
+                        "section": "1.0",
+                        "source_type": "proprietary",
+                    },
+                },
+            ],
+            "deadlines": [
+                {"label": "Application deadline", "due": "2024-11-30"}
+            ],
+        },
+        {
+            "title": "Horizon Europe Mission",
+            "description": "European mission for climate neutral cities with cross-border collaboration.",
+            "deadline": "2025-02-15",
+            "url": "https://research-and-innovation.ec.europa.eu",
+            "jurisdiction": "EU",
+            "entity_types": ["SME", "Consortium"],
+            "industries": ["energy", "mobility"],
+            "project_types": ["urban innovation"],
+            "min_co2_reduction": 100,
+            "max_support": 2000000,
+            "support_unit": "EUR",
+            "rules": [
+                {
+                    "id": "EU-PARTNERS",
+                    "text": "Requires international partnerships with at least two EU member states.",
+                    "field": "partners",
+                    "operator": "contains",
+                    "value": ["international"],
+                    "severity": "required",
+                    "category": "eligibility",
+                    "citation": {
+                        "title": "Horizon Europe Work Programme",
+                        "section": "1.2.5",
+                    },
+                }
+            ],
+            "proprietary_notes": [],
+            "deadlines": [
+                {"label": "Concept note", "due": "2024-09-01"},
+                {"label": "Full proposal", "due": "2025-02-15"},
+            ],
+        },
+    ]
+
+    response = client.post("/grants", json=payload)
+    assert response.status_code == 201, response.text
+    return [grant["id"] for grant in response.json()]
+
+
+def test_end_to_end_journey(client: TestClient) -> None:
+    user_payload = {
+        "name": "Stockholm Mobility",
+        "email": "mobility@example.com",
+        "organization": "Stockholm Mobility Lab",
+        "entity_type": "SME",
+        "location": "Sweden",
+        "industry": "transport",
+        "project_type": "ev charging",
+        "budget_min": 150000,
+        "budget_max": 450000,
+    }
+    user_response = client.post("/users", json=user_payload)
+    assert user_response.status_code == 201
+    user_id = user_response.json()["id"]
+
+    _ingest_sample_grants(client)
+
+    quick_scan_payload = {
+        "user_id": user_id,
+        "industry": "transport",
+        "entity_type": "SME",
+        "location": "Sweden",
+        "project_type": "ev charging",
+        "budget_min": 200000,
+        "budget_max": 500000,
+    }
+    quick_response = client.post("/journey/quick-scan", json=quick_scan_payload)
+    assert quick_response.status_code == 200
+    quick_items = quick_response.json()
+    assert len(quick_items) == 2
+    klimat_status = next(item for item in quick_items if item["grant_title"] == "Klimatklivet")
+    assert klimat_status["status"] in {"Yes", "Maybe"}
+
+    match_payload = {
+        "user_id": user_id,
+        "project_description": "Deploy 6 smart EV chargers rated 120kW across Stockholm's logistics hubs.",
+        "capex": 350000,
+        "opex": 25000,
+        "timeline": "2024-2025",
+        "co2_reduction": 180.5,
+        "partners": "Local utility, municipal transport agency",
+        "top_k": 2,
+    }
+    match_response = client.post("/journey/funding-match", json=match_payload)
+    assert match_response.status_code == 200
+    matches = match_response.json()
+    assert len(matches) == 2
+    top_match = matches[0]
+    assert top_match["grant"]["title"] == "Klimatklivet"
+    assert any(reason["id"] == "KLIM-ELIG-ENTITY" for reason in top_match["reasons"])
+
+    gap_payload = {
+        "match_id": top_match["id"],
+        "assignments": {"KLIM-PROJECT": "Mobility Lead"},
+        "default_owner": "Grants Team",
+        "default_due_in_days": 10,
+    }
+    gap_response = client.post("/journey/gap-plan", json=gap_payload)
+    assert gap_response.status_code == 200
+    tasks = gap_response.json()
+    assert tasks
+    first_task_id = tasks[0]["id"]
+
+    update_response = client.patch(
+        f"/journey/tasks/{first_task_id}", json={"status": "in_progress"}
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["status"] == "in_progress"
+
+    draft_response = client.post(
+        "/journey/application-draft",
+        json={"match_id": top_match["id"], "sections": ["summary", "budget"]},
+    )
+    assert draft_response.status_code == 200
+    drafts = draft_response.json()
+    assert len(drafts) == 2
+    assert drafts[0]["key"] == "summary"
+    assert drafts[0]["citations"]
+
+    evidence_response = client.post(
+        "/journey/evidence-check",
+        json={
+            "match_id": top_match["id"],
+            "documents": [
+                {"requirement": "KLIM-EVID-BASELINE", "file_name": "baseline.pdf"}
+            ],
+        },
+    )
+    assert evidence_response.status_code == 200
+    evidence_items = evidence_response.json()
+    assert evidence_items[0]["status"] in {"missing", "compliant"}
+
+    deadlines_response = client.post(
+        "/journey/deadlines",
+        json={
+            "match_id": top_match["id"],
+            "milestones": [{"label": "Internal review", "due": "2024-10-01"}],
+        },
+    )
+    assert deadlines_response.status_code == 200
+    assert any(item["is_grant_deadline"] for item in deadlines_response.json())
+
+    finalise_response = client.post(
+        "/journey/finalise", json={"match_id": top_match["id"]}
+    )
+    assert finalise_response.status_code == 200
+    finalise_data = finalise_response.json()
+    assert finalise_data["match_id"] == top_match["id"]
+
+    post_response = client.post(
+        "/journey/post-submission", json={"match_id": top_match["id"]}
+    )
+    assert post_response.status_code == 200
+    assert post_response.json()["updates"]

--- a/backend/tests/test_matching.py
+++ b/backend/tests/test_matching.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.matching import MatchingService
+from backend.models import Base, Grant, UserProfile
+
+
+@pytest.fixture()
+def session() -> Session:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = TestingSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def test_matching_ranks_high_relevance_grant(session: Session) -> None:
+    user = UserProfile(
+        name="Researcher One",
+        email="researcher@example.com",
+        focus_areas="artificial intelligence, machine learning",
+        goals="advance trustworthy ai",
+    )
+    session.add(user)
+
+    grants = [
+        Grant(
+            title="AI Safety Research Grant",
+            description="Funding for research into responsible and trustworthy artificial intelligence.",
+            sponsor="Tech Philanthropy",
+        ),
+        Grant(
+            title="Marine Biology Fellowship",
+            description="Support for oceanic wildlife preservation studies.",
+            sponsor="Oceanic Trust",
+        ),
+    ]
+    session.add_all(grants)
+    session.commit()
+
+    service = MatchingService(model_name="test")
+    matches = service.generate_matches(session=session, user=user, top_k=2)
+
+    assert len(matches) == 2
+    assert matches[0].grant.title == "AI Safety Research Grant"
+    assert matches[0].score >= matches[1].score
+
+
+def test_matching_handles_no_grants(session: Session) -> None:
+    user = UserProfile(name="Solo User", email="solo@example.com")
+    session.add(user)
+    session.commit()
+
+    service = MatchingService(model_name="test")
+    matches = service.generate_matches(session=session, user=user, top_k=5)
+
+    assert matches == []

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Grant Matcher</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1988 @@
+{
+  "name": "grant-matching-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grant-matching-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "axios": "^1.6.7",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.3"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.21",
+        "@types/react-dom": "^18.2.7",
+        "@vitejs/plugin-react": "^4.2.0",
+        "typescript": "^5.3.3",
+        "vite": "^5.1.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+      "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+      "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+      "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+      "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+      "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+      "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+      "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+      "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+      "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+      "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+      "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+      "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+      "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+      "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+      "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+      "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+      "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+      "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+      "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+      "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+      "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
+      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.221",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.221.tgz",
+      "integrity": "sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+      "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.50.2",
+        "@rollup/rollup-android-arm64": "4.50.2",
+        "@rollup/rollup-darwin-arm64": "4.50.2",
+        "@rollup/rollup-darwin-x64": "4.50.2",
+        "@rollup/rollup-freebsd-arm64": "4.50.2",
+        "@rollup/rollup-freebsd-x64": "4.50.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+        "@rollup/rollup-linux-arm64-musl": "4.50.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-musl": "4.50.2",
+        "@rollup/rollup-openharmony-arm64": "4.50.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+        "@rollup/rollup-win32-x64-msvc": "4.50.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "grant-matching-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0",
+    "@vitejs/plugin-react": "^4.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Link, Route, Routes } from 'react-router-dom';
+
+import GrantSearchPage from './pages/GrantSearchPage';
+import MatchesPage from './pages/MatchesPage';
+import OnboardingPage from './pages/OnboardingPage';
+
+const App: React.FC = () => {
+  const [userId, setUserId] = useState<number | null>(null);
+
+  return (
+    <div className="app-container">
+      <header>
+        <h1>Grant Matcher</h1>
+        <nav>
+          <Link to="/">Onboarding</Link>
+          <Link to="/grants">Grant search</Link>
+          <Link to="/matches">Recommended matches</Link>
+        </nav>
+      </header>
+      <main>
+        <Routes>
+          <Route path="/" element={<OnboardingPage onProfileCreated={setUserId} />} />
+          <Route path="/grants" element={<GrantSearchPage />} />
+          <Route path="/matches" element={<MatchesPage userId={userId} />} />
+        </Routes>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/components/GrantMatchList.tsx
+++ b/frontend/src/components/GrantMatchList.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { MatchResult } from '../types';
+
+interface Props {
+  matches: MatchResult[];
+  isLoading?: boolean;
+}
+
+const GrantMatchList: React.FC<Props> = ({ matches, isLoading }) => {
+  if (isLoading) {
+    return <p>Loading recommended matches...</p>;
+  }
+
+  if (!matches.length) {
+    return <p>No matches yet. Complete onboarding and ingest grants to see recommendations.</p>;
+  }
+
+  return (
+    <ul className="grant-match-list">
+      {matches.map((match) => (
+        <li key={match.grant.id} className="grant-match">
+          <h3>{match.grant.title}</h3>
+          {match.grant.sponsor && <p className="sponsor">Sponsored by {match.grant.sponsor}</p>}
+          <p>{match.grant.description}</p>
+          <p className="score">Match score: {(match.score * 100).toFixed(1)}%</p>
+          {match.grant.url && (
+            <a href={match.grant.url} target="_blank" rel="noreferrer">
+              View grant details
+            </a>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default GrantMatchList;

--- a/frontend/src/components/GrantSearchForm.tsx
+++ b/frontend/src/components/GrantSearchForm.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+
+import { GrantPayload } from '../types';
+
+interface Props {
+  onIngest: (grants: GrantPayload[]) => Promise<void>;
+}
+
+const defaultGrant: GrantPayload = {
+  title: '',
+  description: '',
+  sponsor: '',
+  deadline: '',
+  url: '',
+};
+
+const GrantSearchForm: React.FC<Props> = ({ onIngest }) => {
+  const [grant, setGrant] = useState<GrantPayload>(defaultGrant);
+  const [message, setMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setGrant((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setMessage(null);
+    try {
+      await onIngest([{ ...grant }]);
+      setMessage('Grant ingested!');
+      setGrant(defaultGrant);
+    } catch (error) {
+      setMessage('Unable to ingest grant.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="grant-ingest-form">
+      <label>
+        Title
+        <input name="title" value={grant.title} onChange={handleChange} required />
+      </label>
+      <label>
+        Description
+        <textarea name="description" value={grant.description} onChange={handleChange} rows={4} required />
+      </label>
+      <label>
+        Sponsor
+        <input name="sponsor" value={grant.sponsor} onChange={handleChange} />
+      </label>
+      <label>
+        Deadline
+        <input name="deadline" value={grant.deadline} onChange={handleChange} />
+      </label>
+      <label>
+        URL
+        <input name="url" value={grant.url} onChange={handleChange} />
+      </label>
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Ingesting...' : 'Ingest grant'}
+      </button>
+      {message && <p className="status">{message}</p>}
+    </form>
+  );
+};
+
+export default GrantSearchForm;

--- a/frontend/src/components/UserOnboardingForm.tsx
+++ b/frontend/src/components/UserOnboardingForm.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+
+import { UserProfilePayload } from '../types';
+
+interface Props {
+  onSubmit: (payload: UserProfilePayload) => Promise<void>;
+}
+
+const emptyForm: UserProfilePayload = {
+  name: '',
+  email: '',
+  organization: '',
+  focus_areas: '',
+  goals: '',
+};
+
+const UserOnboardingForm: React.FC<Props> = ({ onSubmit }) => {
+  const [form, setForm] = useState<UserProfilePayload>(emptyForm);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setMessage(null);
+
+    try {
+      await onSubmit(form);
+      setMessage('Profile saved!');
+    } catch (error) {
+      setMessage('Unable to save profile. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="onboarding-form">
+      <label>
+        Name
+        <input name="name" value={form.name} onChange={handleChange} required />
+      </label>
+      <label>
+        Email
+        <input name="email" type="email" value={form.email} onChange={handleChange} required />
+      </label>
+      <label>
+        Organization
+        <input name="organization" value={form.organization} onChange={handleChange} />
+      </label>
+      <label>
+        Focus Areas
+        <input name="focus_areas" value={form.focus_areas} onChange={handleChange} />
+      </label>
+      <label>
+        Goals
+        <textarea name="goals" value={form.goals} onChange={handleChange} rows={4} />
+      </label>
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Saving...' : 'Save profile'}
+      </button>
+      {message && <p className="status">{message}</p>}
+    </form>
+  );
+};
+
+export default UserOnboardingForm;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/GrantSearchPage.tsx
+++ b/frontend/src/pages/GrantSearchPage.tsx
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import React from 'react';
+
+import GrantSearchForm from '../components/GrantSearchForm';
+import { GrantPayload } from '../types';
+
+const GrantSearchPage: React.FC = () => {
+  const handleIngest = async (grants: GrantPayload[]) => {
+    await axios.post('/api/grants', grants);
+  };
+
+  return (
+    <section>
+      <h2>Ingest new grants</h2>
+      <p>Paste relevant information about opportunities to keep the recommendation engine up to date.</p>
+      <GrantSearchForm onIngest={handleIngest} />
+    </section>
+  );
+};
+
+export default GrantSearchPage;

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+
+import GrantMatchList from '../components/GrantMatchList';
+import { MatchResult } from '../types';
+
+interface Props {
+  userId: number | null;
+}
+
+const MatchesPage: React.FC<Props> = ({ userId }) => {
+  const [matches, setMatches] = useState<MatchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchMatches = async () => {
+      if (!userId) {
+        setMatches([]);
+        return;
+      }
+      setIsLoading(true);
+      try {
+        const response = await axios.get(`/api/matches/${userId}`);
+        setMatches(response.data);
+      } catch (error) {
+        setMatches([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMatches();
+  }, [userId]);
+
+  if (!userId) {
+    return <p>Create a user profile to unlock personalized matches.</p>;
+  }
+
+  return (
+    <section>
+      <h2>Recommended Matches</h2>
+      <GrantMatchList matches={matches} isLoading={isLoading} />
+    </section>
+  );
+};
+
+export default MatchesPage;

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import React from 'react';
+
+import UserOnboardingForm from '../components/UserOnboardingForm';
+import { UserProfilePayload } from '../types';
+
+interface Props {
+  onProfileCreated: (userId: number) => void;
+}
+
+const OnboardingPage: React.FC<Props> = ({ onProfileCreated }) => {
+  const handleSubmit = async (payload: UserProfilePayload) => {
+    const response = await axios.post('/api/users', payload);
+    onProfileCreated(response.data.id);
+  };
+
+  return (
+    <section>
+      <h2>Welcome to Grant Matcher</h2>
+      <p>Tell us about your organization to personalize the grants we recommend.</p>
+      <UserOnboardingForm onSubmit={handleSubmit} />
+    </section>
+  );
+};
+
+export default OnboardingPage;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,20 @@
+export interface UserProfilePayload {
+  name: string;
+  email: string;
+  organization?: string;
+  focus_areas?: string;
+  goals?: string;
+}
+
+export interface GrantPayload {
+  title: string;
+  description: string;
+  sponsor?: string;
+  deadline?: string;
+  url?: string;
+}
+
+export interface MatchResult {
+  grant: GrantPayload & { id: number };
+  score: number;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- extend the Menmo backend models to capture project profiles, stored quick scans, remediation tasks, application sections, evidence status and deadline milestones
- add a journey service plus retrieval engine to drive the Quick Scan, Funding Match, Gap-to-Yes, Application Builder, Evidence AutoCheck, Deadline Radar, Finalisation and Post-Submission stages
- expose the multi-stage FastAPI endpoints, seed RAG documents and document the full journey and setup flow in the README

## Testing
- pytest backend/tests


------
https://chatgpt.com/codex/tasks/task_e_68cc1a8797388331ac050a3bdb77cb5b