### PR TITLE
Create Menmo enterprise dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# Menmo
-menmo.ai
+# Menmo Enterprise Suite
+
+A modern, Oracle-inspired executive workspace that showcases how Menmo could unify delivery, finance, people and automation insights in a single experience.
+
+## Getting started
+
+The experience is a static web application – no build tooling is required.
+
+```bash
+# from the repository root
+python -m http.server 5173
+```
+
+Open your browser at <http://localhost:5173> to explore the dashboard.
+
+## Highlights
+
+- Responsive enterprise shell with collapsible navigation and executive header
+- Dynamic data views for programmes, automation workflows, people insights and activity stream
+- Interactive command palette, modal workflows and global search that feel native to modern SaaS suites
+- Light and dark themes with persistent preferences and radar chart visualisations powered by Chart.js
+
+## Tech stack
+
+- HTML, CSS and modern JavaScript (no build step required)
+- [Chart.js](https://www.chartjs.org/) via CDN for lightweight visualisation

--- a/index.html
+++ b/index.html
@@ -1,0 +1,411 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Menmo Enterprise Suite</title>
+    <meta
+      name="description"
+      content="A modern enterprise management experience inspired by Oracle apps"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='24' fill='%23ff4d4d'/><path d='M20 70 L50 20 L80 70' stroke='white' stroke-width='10' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>" />
+    <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script defer src="scripts/app.js"></script>
+  </head>
+  <body>
+    <div class="app-shell" data-theme="light">
+      <aside class="shell__sidebar">
+        <div class="sidebar__brand">
+          <span class="brand__icon">M</span>
+          <div>
+            <span class="brand__title">Menmo</span>
+            <span class="brand__subtitle">Enterprise Suite</span>
+          </div>
+        </div>
+        <nav class="sidebar__nav">
+          <div class="nav__group">
+            <p class="nav__label">Workspace</p>
+            <a class="nav__item nav__item--active" href="#dashboard">
+              <span class="nav__icon" aria-hidden="true">🏠</span>
+              Dashboard
+            </a>
+            <a class="nav__item" href="#portfolios">
+              <span class="nav__icon" aria-hidden="true">📦</span>
+              Portfolios
+            </a>
+            <a class="nav__item" href="#projects">
+              <span class="nav__icon" aria-hidden="true">🗂️</span>
+              Projects
+            </a>
+            <a class="nav__item" href="#finance">
+              <span class="nav__icon" aria-hidden="true">💳</span>
+              Finance
+            </a>
+            <a class="nav__item" href="#people">
+              <span class="nav__icon" aria-hidden="true">👥</span>
+              People
+            </a>
+          </div>
+          <div class="nav__group">
+            <p class="nav__label">Analytics</p>
+            <a class="nav__item" href="#insights">
+              <span class="nav__icon" aria-hidden="true">📊</span>
+              Insights
+            </a>
+            <a class="nav__item" href="#reports">
+              <span class="nav__icon" aria-hidden="true">📈</span>
+              Reports
+            </a>
+            <a class="nav__item" href="#automation">
+              <span class="nav__icon" aria-hidden="true">⚙️</span>
+              Automation
+            </a>
+          </div>
+        </nav>
+        <div class="sidebar__footer">
+          <div class="sidebar__plan">
+            <span class="plan__label">Platform score</span>
+            <div class="plan__score">
+              <span>92</span>
+              <small>/100</small>
+            </div>
+            <p class="plan__description">
+              Performance is trending upward. Review insights for optimisation.
+            </p>
+            <button class="button button--secondary" type="button">
+              View recommendations
+            </button>
+          </div>
+          <button class="button button--ghost" type="button" id="commandPaletteButton">
+            <span aria-hidden="true">⌘</span>
+            Command palette
+          </button>
+        </div>
+      </aside>
+
+      <main class="shell__content" id="dashboard">
+        <header class="content__header">
+          <div class="header__context">
+            <button class="button button--ghost button--icon" type="button" id="mobileMenu">
+              <span aria-hidden="true">☰</span>
+              <span class="sr-only">Toggle navigation</span>
+            </button>
+            <div>
+              <h1>Executive Overview</h1>
+              <p>Monitor performance, financials, people and automation in one workspace.</p>
+            </div>
+          </div>
+          <div class="header__actions">
+            <div class="search" role="search">
+              <input
+                class="search__input"
+                type="search"
+                id="globalSearch"
+                placeholder="Search projects, teams or reports..."
+                aria-label="Search"
+              />
+              <span class="search__icon" aria-hidden="true">🔍</span>
+            </div>
+            <button class="button button--ghost" type="button" id="themeToggle" aria-pressed="false">
+              <span class="theme-toggle__icon" aria-hidden="true">🌞</span>
+              <span class="sr-only">Toggle theme</span>
+            </button>
+            <button class="button button--primary" type="button" id="openCreateModal">
+              <span aria-hidden="true">＋</span>
+              New initiative
+            </button>
+            <div class="user">
+              <span class="user__avatar" aria-hidden="true">AV</span>
+              <div>
+                <p class="user__name">Avery Vaughn</p>
+                <p class="user__role">Chief Operating Officer</p>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section class="panel panel--highlight">
+          <div class="panel__content">
+            <h2>Quarterly outlook</h2>
+            <p>
+              Cross-functional alignment has improved by <strong>12%</strong> this month. Automation pipelines reduced manual effort by <strong>340 hours</strong> and finance is trending <strong>8% under budget</strong>.
+            </p>
+            <div class="panel__tags">
+              <span class="tag">Alignment</span>
+              <span class="tag">Automation</span>
+              <span class="tag">Financial health</span>
+            </div>
+          </div>
+          <div class="panel__figure">
+            <div class="donut" role="img" aria-label="74 percent progress">
+              <svg viewBox="0 0 36 36">
+                <path class="donut__track" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831a 15.9155 15.9155 0 0 1 0 -31.831" />
+                <path class="donut__indicator" stroke-dasharray="74, 100" d="M18 2.0845a 15.9155 15.9155 0 0 1 0 31.831a 15.9155 15.9155 0 0 1 0 -31.831" />
+                <text x="18" y="20.35" class="donut__text">74%</text>
+              </svg>
+            </div>
+          </div>
+        </section>
+
+        <section class="grid grid--metrics" aria-label="Key metrics">
+          <article class="metric" data-metric="revenue">
+            <header>
+              <span class="metric__icon" aria-hidden="true">💰</span>
+              <div>
+                <p class="metric__label">Revenue impact</p>
+                <p class="metric__value" id="metricRevenue">$8.4M</p>
+              </div>
+            </header>
+            <p class="metric__trend metric__trend--positive">+4.3% vs forecast</p>
+          </article>
+          <article class="metric" data-metric="delivery">
+            <header>
+              <span class="metric__icon" aria-hidden="true">🚀</span>
+              <div>
+                <p class="metric__label">On-time delivery</p>
+                <p class="metric__value" id="metricDelivery">94%</p>
+              </div>
+            </header>
+            <p class="metric__trend metric__trend--positive">+6.2% this month</p>
+          </article>
+          <article class="metric" data-metric="automation">
+            <header>
+              <span class="metric__icon" aria-hidden="true">🤖</span>
+              <div>
+                <p class="metric__label">Automation coverage</p>
+                <p class="metric__value" id="metricAutomation">68%</p>
+              </div>
+            </header>
+            <p class="metric__trend metric__trend--neutral">17 pipelines live</p>
+          </article>
+          <article class="metric" data-metric="satisfaction">
+            <header>
+              <span class="metric__icon" aria-hidden="true">😊</span>
+              <div>
+                <p class="metric__label">Employee satisfaction</p>
+                <p class="metric__value" id="metricSatisfaction">8.9</p>
+              </div>
+            </header>
+            <p class="metric__trend metric__trend--positive">+0.6 QoQ</p>
+          </article>
+        </section>
+
+        <section class="grid grid--columns">
+          <section class="panel" aria-labelledby="deliveryPipeline">
+            <div class="panel__header">
+              <div>
+                <h2 id="deliveryPipeline">Delivery pipeline</h2>
+                <p>Track programmes by health, owner, automation coverage and forecast.</p>
+              </div>
+              <div class="panel__actions">
+                <label class="select" aria-label="Filter by health">
+                  <select id="healthFilter">
+                    <option value="all">All health states</option>
+                    <option value="on-track">On track</option>
+                    <option value="at-risk">At risk</option>
+                    <option value="blocked">Blocked</option>
+                  </select>
+                </label>
+              </div>
+            </div>
+            <div class="table-responsive">
+              <table class="table" aria-describedby="deliveryPipeline">
+                <thead>
+                  <tr>
+                    <th scope="col" data-sort="name">Programme</th>
+                    <th scope="col" data-sort="owner">Owner</th>
+                    <th scope="col" data-sort="status">Health</th>
+                    <th scope="col" data-sort="automation">Automation</th>
+                    <th scope="col" data-sort="budget">Budget</th>
+                    <th scope="col" data-sort="forecast">Forecast</th>
+                  </tr>
+                </thead>
+                <tbody id="programmeTableBody"></tbody>
+              </table>
+            </div>
+          </section>
+
+          <section class="panel" aria-labelledby="teamPerformance">
+            <div class="panel__header">
+              <div>
+                <h2 id="teamPerformance">Team performance</h2>
+                <p>Compare velocity, quality and capacity across core delivery teams.</p>
+              </div>
+              <div class="panel__actions">
+                <label class="select" aria-label="Period">
+                  <select id="performancePeriod">
+                    <option value="month">Last 30 days</option>
+                    <option value="quarter">Quarter</option>
+                    <option value="year">Year</option>
+                  </select>
+                </label>
+              </div>
+            </div>
+            <canvas id="performanceChart" height="220" role="img" aria-label="Team performance chart"></canvas>
+            <ul class="legend" id="performanceLegend" aria-label="Team performance legend"></ul>
+          </section>
+        </section>
+
+        <section class="grid grid--columns">
+          <section class="panel" aria-labelledby="workflows">
+            <div class="panel__header">
+              <div>
+                <h2 id="workflows">Automation workflows</h2>
+                <p>Review the newest automations rolled out across business units.</p>
+              </div>
+            </div>
+            <ul class="workflow" id="workflowList"></ul>
+          </section>
+
+          <section class="panel" aria-labelledby="peopleInsights">
+            <div class="panel__header">
+              <div>
+                <h2 id="peopleInsights">People insights</h2>
+                <p>Engagement drivers, retention risks and succession planning updates.</p>
+              </div>
+              <div class="panel__actions">
+                <label class="switch">
+                  <input type="checkbox" id="pulseToggle" />
+                  <span>Live pulse</span>
+                </label>
+              </div>
+            </div>
+            <div class="insights" id="insightsGrid"></div>
+          </section>
+        </section>
+
+        <section class="grid grid--columns">
+          <section class="panel" aria-labelledby="activityStream">
+            <div class="panel__header">
+              <div>
+                <h2 id="activityStream">Activity stream</h2>
+                <p>Highlights from operations, finance and automation in the last 48 hours.</p>
+              </div>
+              <button class="button button--ghost" type="button" id="refreshActivity">Refresh</button>
+            </div>
+            <ul class="timeline" id="activityTimeline"></ul>
+          </section>
+
+          <section class="panel" aria-labelledby="portfolioHealth">
+            <div class="panel__header">
+              <div>
+                <h2 id="portfolioHealth">Portfolio health</h2>
+                <p>Blended risk across portfolios with actions to maintain momentum.</p>
+              </div>
+            </div>
+            <div class="portfolio" id="portfolioGrid"></div>
+          </section>
+        </section>
+
+        <section class="panel panel--cta" aria-labelledby="cta">
+          <div>
+            <h2 id="cta">Accelerate delivery with Menmo AI</h2>
+            <p>
+              Configure orchestrated workflows, predictive staffing and intelligent budgeting in minutes. Scale enterprise productivity with automated guardrails.
+            </p>
+          </div>
+          <button class="button button--primary" type="button">Launch AI copilots</button>
+        </section>
+
+        <footer class="footer">
+          <p>Menmo Enterprise Suite &copy; <span id="footerYear"></span>. Built for the modern enterprise.</p>
+          <div class="footer__links">
+            <a href="#">Status</a>
+            <a href="#">Trust &amp; security</a>
+            <a href="#">Privacy</a>
+            <a href="#">Contact</a>
+          </div>
+        </footer>
+      </main>
+
+      <button class="button button--floating" id="quickAction" type="button" aria-haspopup="dialog">
+        <span aria-hidden="true">⚡</span>
+        <span class="sr-only">Open quick actions</span>
+      </button>
+
+      <dialog class="modal" id="createModal">
+        <form class="modal__content" method="dialog">
+          <header class="modal__header">
+            <div>
+              <h2>Create new initiative</h2>
+              <p>Set up owners, milestones and automations before kickoff.</p>
+            </div>
+            <button class="button button--ghost button--icon" type="reset" value="cancel">
+              <span aria-hidden="true">✕</span>
+              <span class="sr-only">Close</span>
+            </button>
+          </header>
+          <div class="modal__body">
+            <label class="field">
+              <span>Initiative name</span>
+              <input type="text" name="name" required placeholder="Connected fulfilment platform" />
+            </label>
+            <div class="field-group">
+              <label class="field">
+                <span>Executive sponsor</span>
+                <input type="text" name="sponsor" required placeholder="Jane Doe" />
+              </label>
+              <label class="field">
+                <span>Business unit</span>
+                <select name="unit" required>
+                  <option value="">Select unit</option>
+                  <option>Commerce</option>
+                  <option>Operations</option>
+                  <option>Finance</option>
+                  <option>People</option>
+                </select>
+              </label>
+            </div>
+            <label class="field">
+              <span>Primary objective</span>
+              <textarea name="objective" rows="3" placeholder="Reduce cost-to-serve by 14% through automation"></textarea>
+            </label>
+            <label class="field field--inline">
+              <input type="checkbox" name="automation" checked />
+              <span>Enable automation recommendations</span>
+            </label>
+          </div>
+          <footer class="modal__footer">
+            <button class="button button--ghost" type="reset" value="cancel">Cancel</button>
+            <button class="button button--primary" type="submit">Create initiative</button>
+          </footer>
+        </form>
+      </dialog>
+
+      <div class="command-palette" id="commandPalette" role="dialog" aria-modal="true" aria-labelledby="commandPaletteTitle" hidden>
+        <div class="command-palette__panel">
+          <header>
+            <h2 id="commandPaletteTitle">Command palette</h2>
+            <p>Jump to reports, open automations or create new work.</p>
+          </header>
+          <input
+            class="command-palette__search"
+            type="search"
+            id="commandPaletteSearch"
+            placeholder="Type a command or search"
+            aria-label="Command search"
+          />
+          <ul class="command-palette__list" id="commandPaletteList"></ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite" hidden>
+      <span class="toast__icon" aria-hidden="true">✅</span>
+      <span id="toastMessage">Initiative created successfully.</span>
+    </div>
+
+    <template id="commandTemplate">
+      <li>
+        <button type="button"></button>
+      </li>
+    </template>
+  </body>
+</html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,608 @@
+const appShell = document.querySelector('.app-shell');
+const sidebar = document.querySelector('.shell__sidebar');
+const themeToggle = document.getElementById('themeToggle');
+const mobileMenu = document.getElementById('mobileMenu');
+const healthFilter = document.getElementById('healthFilter');
+const performancePeriod = document.getElementById('performancePeriod');
+const programmeTableBody = document.getElementById('programmeTableBody');
+const workflowList = document.getElementById('workflowList');
+const insightsGrid = document.getElementById('insightsGrid');
+const activityTimeline = document.getElementById('activityTimeline');
+const portfolioGrid = document.getElementById('portfolioGrid');
+const footerYear = document.getElementById('footerYear');
+const commandPalette = document.getElementById('commandPalette');
+const commandPaletteButton = document.getElementById('commandPaletteButton');
+const commandPaletteSearch = document.getElementById('commandPaletteSearch');
+const commandPaletteList = document.getElementById('commandPaletteList');
+const commandTemplate = document.getElementById('commandTemplate');
+const globalSearch = document.getElementById('globalSearch');
+const quickAction = document.getElementById('quickAction');
+const openCreateModal = document.getElementById('openCreateModal');
+const createModal = document.getElementById('createModal');
+const toast = document.getElementById('toast');
+const toastMessage = document.getElementById('toastMessage');
+const refreshActivity = document.getElementById('refreshActivity');
+const pulseToggle = document.getElementById('pulseToggle');
+
+footerYear.textContent = new Date().getFullYear();
+
+const state = {
+  programmes: [
+    {
+      name: 'Global Commerce Re-platform',
+      owner: 'Luna Larson',
+      status: 'on-track',
+      automation: 0.68,
+      budget: '$2.6M',
+      forecast: '-4.8% under',
+    },
+    {
+      name: 'Predictive Inventory Network',
+      owner: 'Zayn Ellison',
+      status: 'at-risk',
+      automation: 0.42,
+      budget: '$1.9M',
+      forecast: '+3.2% over',
+    },
+    {
+      name: 'Finance Intelligence Fabric',
+      owner: 'Ivy Chen',
+      status: 'on-track',
+      automation: 0.74,
+      budget: '$2.1M',
+      forecast: '-7.4% under',
+    },
+    {
+      name: 'Automated Supplier Exchange',
+      owner: 'Diego Alvarez',
+      status: 'blocked',
+      automation: 0.33,
+      budget: '$1.2M',
+      forecast: '+9.0% over',
+    },
+    {
+      name: 'Customer Journey Orchestration',
+      owner: 'Priya Desai',
+      status: 'on-track',
+      automation: 0.58,
+      budget: '$980K',
+      forecast: '-1.6% under',
+    },
+  ],
+  workflows: [
+    {
+      title: 'Invoice validation copilot',
+      detail: 'Uses document AI to reconcile invoices to purchase orders in real time.',
+      meta: ['Finance', 'Saved 420 hours', '99.2% accuracy'],
+    },
+    {
+      title: 'Predictive talent mobility',
+      detail: 'Aggregates performance data to surface succession candidates automatically.',
+      meta: ['People', '+18% internal mobility', 'Live in 6 regions'],
+    },
+    {
+      title: 'Logistics exception routing',
+      detail: 'Proactively reroutes shipments when fulfilment SLAs fall below thresholds.',
+      meta: ['Operations', '-12% delays', 'AI-driven'],
+    },
+  ],
+  insights: [
+    {
+      label: 'Engagement driver',
+      value: 'Growth conversations every 45 days correlate to +11% retention.',
+    },
+    {
+      label: 'Automation opportunity',
+      value: 'Manual approvals in Finance Ops consume 290 hours per month.',
+    },
+    {
+      label: 'Talent risk',
+      value: 'Two critical squads exceed 35% attrition risk; succession ready in 60 days.',
+    },
+    {
+      label: 'Experience pulse',
+      value: 'Service NPS +9 vs industry benchmark over the last quarter.',
+    },
+  ],
+  activities: [
+    {
+      title: 'Operations automation pushed',
+      detail: 'New SLA guardrails deployed across fulfilment centres.',
+      timestamp: '2h ago • Automation',
+    },
+    {
+      title: 'Budget revision approved',
+      detail: 'Finance authorised a 6% increase to meet accelerated go-live.',
+      timestamp: '6h ago • Finance',
+    },
+    {
+      title: 'Talent heatmap refreshed',
+      detail: 'Live data sync complete for EMEA and APAC squads.',
+      timestamp: '12h ago • People',
+    },
+    {
+      title: 'Executive sync recorded',
+      detail: 'Highlights alignment improvements and next quarter bets.',
+      timestamp: '1d ago • Leadership',
+    },
+  ],
+  portfolios: [
+    {
+      name: 'Connected Commerce',
+      health: 'Stable',
+      trend: '+6.4% velocity',
+      summary: 'Marketplace, storefront and loyalty roadmaps shipped on schedule.',
+    },
+    {
+      name: 'Intelligent Operations',
+      health: 'Accelerating',
+      trend: '+11% automation coverage',
+      summary: 'Network digitisation unlocking faster fulfilment and fewer escalations.',
+    },
+    {
+      name: 'Finance Transformation',
+      health: 'Watchlist',
+      trend: '-2.1% forecast',
+      summary: 'Need to stabilise supplier integration before scaling next phase.',
+    },
+  ],
+  commands: [
+    { label: 'Create initiative', description: 'Launch the initiative wizard', action: () => openModal() },
+    {
+      label: 'Open automations',
+      description: 'Jump to automation workflows',
+      action: () => scrollToSection('#workflows'),
+    },
+    {
+      label: 'View portfolio health',
+      description: 'Focus the portfolio section',
+      action: () => scrollToSection('#portfolioHealth'),
+    },
+    { label: 'Toggle theme', description: 'Switch between light and dark mode', action: () => toggleTheme() },
+  ],
+  sort: {
+    key: null,
+    direction: 'asc',
+  },
+};
+
+const formatStatus = (status) => {
+  const map = {
+    'on-track': 'status status--on-track',
+    'at-risk': 'status status--at-risk',
+    blocked: 'status status--blocked',
+  };
+  const label = {
+    'on-track': 'On track',
+    'at-risk': 'At risk',
+    blocked: 'Blocked',
+  };
+  return `<span class="${map[status]}">${label[status]}</span>`;
+};
+
+const formatAutomation = (value) => `${Math.round(value * 100)}%`;
+
+const renderProgrammeTable = () => {
+  const query = globalSearch.value.trim().toLowerCase();
+  const filter = healthFilter.value;
+  const programmes = state.programmes
+    .filter((programme) =>
+      query
+        ? programme.name.toLowerCase().includes(query) ||
+          programme.owner.toLowerCase().includes(query)
+        : true,
+    )
+    .filter((programme) => (filter === 'all' ? true : programme.status === filter));
+
+  const sorted = [...programmes];
+  if (state.sort.key) {
+    sorted.sort((a, b) => {
+      const { key, direction } = state.sort;
+      const order = direction === 'asc' ? 1 : -1;
+
+      if (key === 'automation') {
+        return (a[key] - b[key]) * order;
+      }
+
+      const valueA = a[key].toString().toLowerCase();
+      const valueB = b[key].toString().toLowerCase();
+
+      if (valueA < valueB) return -1 * order;
+      if (valueA > valueB) return 1 * order;
+      return 0;
+    });
+  }
+
+  programmeTableBody.innerHTML = sorted
+    .map(
+      (programme) => `
+        <tr>
+          <th scope="row">${programme.name}</th>
+          <td>${programme.owner}</td>
+          <td>${formatStatus(programme.status)}</td>
+          <td>${formatAutomation(programme.automation)}</td>
+          <td>${programme.budget}</td>
+          <td>${programme.forecast}</td>
+        </tr>
+      `,
+    )
+    .join('');
+};
+
+const renderWorkflows = () => {
+  workflowList.innerHTML = state.workflows
+    .map(
+      (workflow) => `
+        <li>
+          <strong>${workflow.title}</strong>
+          <p>${workflow.detail}</p>
+          <div class="workflow__meta">
+            ${workflow.meta.map((item) => `<span>${item}</span>`).join('')}
+          </div>
+        </li>
+      `,
+    )
+    .join('');
+};
+
+const renderInsights = () => {
+  insightsGrid.innerHTML = state.insights
+    .map(
+      (insight) => `
+        <article class="insight">
+          <span class="tag">${insight.label}</span>
+          <strong>${insight.value}</strong>
+        </article>
+      `,
+    )
+    .join('');
+};
+
+const renderActivities = () => {
+  activityTimeline.innerHTML = state.activities
+    .map(
+      (activity) => `
+        <li>
+          <strong>${activity.title}</strong>
+          <p>${activity.detail}</p>
+          <span class="timeline__meta">${activity.timestamp}</span>
+        </li>
+      `,
+    )
+    .join('');
+};
+
+const renderPortfolio = () => {
+  portfolioGrid.innerHTML = state.portfolios
+    .map(
+      (portfolio) => `
+        <article class="portfolio-card">
+          <div class="portfolio-card__header">
+            <strong>${portfolio.name}</strong>
+            <span class="portfolio-card__badge">${portfolio.health}</span>
+          </div>
+          <p class="portfolio-card__trend">${portfolio.trend}</p>
+          <p>${portfolio.summary}</p>
+        </article>
+      `,
+    )
+    .join('');
+};
+
+const renderCommands = (commands = state.commands) => {
+  commandPaletteList.innerHTML = '';
+  commands.forEach((command) => {
+    const commandNode = commandTemplate.content.cloneNode(true);
+    const button = commandNode.querySelector('button');
+    button.innerHTML = `
+      <span>${command.label}</span>
+      <small>${command.description}</small>
+    `;
+    button.addEventListener('click', () => {
+      command.action?.();
+      hideCommandPalette();
+    });
+    commandPaletteList.appendChild(commandNode);
+  });
+};
+
+const filterCommands = () => {
+  const query = commandPaletteSearch.value.trim().toLowerCase();
+  if (!query) {
+    renderCommands();
+    return;
+  }
+  const filtered = state.commands.filter((command) =>
+    command.label.toLowerCase().includes(query) ||
+    command.description.toLowerCase().includes(query),
+  );
+  renderCommands(filtered);
+};
+
+const showCommandPalette = () => {
+  commandPalette.hidden = false;
+  commandPaletteSearch.value = '';
+  renderCommands();
+  requestAnimationFrame(() => commandPaletteSearch.focus());
+  document.addEventListener('keydown', handleCommandEscape);
+};
+
+const hideCommandPalette = () => {
+  commandPalette.hidden = true;
+  document.removeEventListener('keydown', handleCommandEscape);
+};
+
+const handleCommandEscape = (event) => {
+  if (event.key === 'Escape') {
+    hideCommandPalette();
+  }
+};
+
+commandPalette.addEventListener('click', (event) => {
+  if (event.target === commandPalette) {
+    hideCommandPalette();
+  }
+});
+
+commandPaletteSearch.addEventListener('input', filterCommands);
+commandPaletteButton.addEventListener('click', showCommandPalette);
+quickAction.addEventListener('click', showCommandPalette);
+
+document.addEventListener('keydown', (event) => {
+  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+    event.preventDefault();
+    if (commandPalette.hidden) {
+      showCommandPalette();
+    } else {
+      hideCommandPalette();
+    }
+  }
+});
+
+const showToast = (message) => {
+  toastMessage.textContent = message;
+  toast.hidden = false;
+  setTimeout(() => {
+    toast.hidden = true;
+  }, 2800);
+};
+
+const openModal = () => {
+  if (typeof createModal.showModal === 'function') {
+    createModal.showModal();
+  } else {
+    showToast('Modal is not supported in this browser.');
+  }
+};
+
+const closeModal = () => createModal.close();
+
+createModal.addEventListener('close', () => {
+  if (createModal.returnValue === 'cancel') return;
+  showToast('Initiative created successfully.');
+});
+
+createModal.addEventListener('submit', (event) => {
+  event.preventDefault();
+  closeModal();
+});
+
+openCreateModal.addEventListener('click', openModal);
+
+const applyTheme = (theme) => {
+  appShell.dataset.theme = theme;
+  localStorage.setItem('menmo-theme', theme);
+  themeToggle.setAttribute('aria-pressed', theme === 'dark');
+  themeToggle.querySelector('.theme-toggle__icon').textContent =
+    theme === 'dark' ? '🌙' : '🌞';
+};
+
+const toggleTheme = () => {
+  const theme = appShell.dataset.theme === 'dark' ? 'light' : 'dark';
+  applyTheme(theme);
+};
+
+themeToggle.addEventListener('click', toggleTheme);
+
+const savedTheme = localStorage.getItem('menmo-theme');
+if (savedTheme === 'dark') {
+  applyTheme('dark');
+}
+
+mobileMenu.addEventListener('click', () => {
+  sidebar.classList.toggle('is-open');
+});
+
+const closeSidebarOnOutsideClick = (event) => {
+  if (!sidebar.contains(event.target) && !mobileMenu.contains(event.target)) {
+    sidebar.classList.remove('is-open');
+  }
+};
+
+document.addEventListener('click', (event) => {
+  if (window.innerWidth <= 1200) {
+    closeSidebarOnOutsideClick(event);
+  }
+});
+
+const sortBy = (key) => {
+  if (state.sort.key === key) {
+    state.sort.direction = state.sort.direction === 'asc' ? 'desc' : 'asc';
+  } else {
+    state.sort.key = key;
+    state.sort.direction = 'asc';
+  }
+  renderProgrammeTable();
+};
+
+Array.from(document.querySelectorAll('.table th[data-sort]')).forEach((header) => {
+  header.addEventListener('click', () => sortBy(header.dataset.sort));
+});
+
+healthFilter.addEventListener('change', renderProgrammeTable);
+globalSearch.addEventListener('input', renderProgrammeTable);
+
+const performanceConfig = {
+  month: {
+    labels: ['Squad Atlas', 'Squad Nova', 'Squad Pulse', 'Squad Flux'],
+    datasets: [
+      {
+        label: 'Velocity',
+        data: [82, 76, 88, 71],
+        backgroundColor: 'rgba(59, 130, 246, 0.65)',
+      },
+      {
+        label: 'Quality',
+        data: [93, 89, 97, 90],
+        backgroundColor: 'rgba(16, 185, 129, 0.65)',
+      },
+      {
+        label: 'Capacity',
+        data: [78, 82, 75, 80],
+        backgroundColor: 'rgba(251, 191, 36, 0.75)',
+      },
+    ],
+  },
+  quarter: {
+    labels: ['Squad Atlas', 'Squad Nova', 'Squad Pulse', 'Squad Flux'],
+    datasets: [
+      {
+        label: 'Velocity',
+        data: [79, 74, 85, 70],
+        backgroundColor: 'rgba(59, 130, 246, 0.65)',
+      },
+      {
+        label: 'Quality',
+        data: [91, 88, 95, 89],
+        backgroundColor: 'rgba(16, 185, 129, 0.65)',
+      },
+      {
+        label: 'Capacity',
+        data: [75, 80, 74, 79],
+        backgroundColor: 'rgba(251, 191, 36, 0.75)',
+      },
+    ],
+  },
+  year: {
+    labels: ['Squad Atlas', 'Squad Nova', 'Squad Pulse', 'Squad Flux'],
+    datasets: [
+      {
+        label: 'Velocity',
+        data: [74, 72, 81, 68],
+        backgroundColor: 'rgba(59, 130, 246, 0.65)',
+      },
+      {
+        label: 'Quality',
+        data: [88, 85, 92, 86],
+        backgroundColor: 'rgba(16, 185, 129, 0.65)',
+      },
+      {
+        label: 'Capacity',
+        data: [72, 76, 70, 74],
+        backgroundColor: 'rgba(251, 191, 36, 0.75)',
+      },
+    ],
+  },
+};
+
+let performanceChartInstance;
+
+const renderPerformanceChart = (period = 'month') => {
+  const ctx = document.getElementById('performanceChart');
+  const config = performanceConfig[period];
+
+  if (!performanceChartInstance) {
+    performanceChartInstance = new Chart(ctx, {
+      type: 'radar',
+      data: config,
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          r: {
+            beginAtZero: true,
+            angleLines: { color: 'rgba(148, 163, 184, 0.16)' },
+            grid: { color: 'rgba(148, 163, 184, 0.16)' },
+            suggestedMax: 100,
+            ticks: {
+              backdropColor: 'transparent',
+              color: 'var(--color-text-subtle)',
+            },
+            pointLabels: {
+              color: 'var(--color-text-subtle)',
+              font: { size: 12 },
+            },
+          },
+        },
+        plugins: {
+          legend: { display: false },
+        },
+      },
+    });
+  } else {
+    performanceChartInstance.data = config;
+    performanceChartInstance.update();
+  }
+
+  renderLegend(config.datasets);
+};
+
+const renderLegend = (datasets) => {
+  const legend = document.getElementById('performanceLegend');
+  legend.innerHTML = datasets
+    .map(
+      (dataset) => `
+        <li>
+          <span class="legend__dot" style="background:${dataset.backgroundColor}"></span>
+          <span>${dataset.label}</span>
+        </li>
+      `,
+    )
+    .join('');
+};
+
+performancePeriod.addEventListener('change', (event) => {
+  renderPerformanceChart(event.target.value);
+});
+
+refreshActivity.addEventListener('click', () => {
+  state.activities.unshift({
+    title: 'AI guardrails tuned',
+    detail: 'Automation policies updated to reflect new compliance thresholds.',
+    timestamp: 'Just now • Automation',
+  });
+  if (state.activities.length > 6) {
+    state.activities.pop();
+  }
+  renderActivities();
+  showToast('Activity stream refreshed.');
+});
+
+pulseToggle.addEventListener('change', (event) => {
+  if (event.target.checked) {
+    showToast('Live pulse streaming enabled.');
+  } else {
+    showToast('Live pulse streaming paused.');
+  }
+});
+
+const scrollToSection = (selector) => {
+  const element = document.querySelector(selector);
+  if (element) {
+    element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+};
+
+renderProgrammeTable();
+renderWorkflows();
+renderInsights();
+renderActivities();
+renderPortfolio();
+renderPerformanceChart();
+renderCommands();
+
+if (!('showModal' in HTMLDialogElement.prototype)) {
+  createModal.setAttribute('open', '');
+  createModal.querySelector('.modal__footer').hidden = true;
+  createModal.querySelector('form').setAttribute('aria-live', 'polite');
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,1045 @@
+:root {
+  color-scheme: light;
+  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --radius-sm: 10px;
+  --radius-md: 16px;
+  --radius-lg: 22px;
+  --shadow-sm: 0 8px 20px rgba(15, 23, 42, 0.05);
+  --shadow-lg: 0 25px 50px -12px rgba(15, 23, 42, 0.22);
+
+  --color-surface: #ffffff;
+  --color-surface-subtle: #f6f7fb;
+  --color-surface-elevated: #ffffff;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --color-text: #0f172a;
+  --color-text-subtle: #334155;
+  --color-accent: #ff4d4d;
+  --color-accent-soft: rgba(255, 77, 77, 0.15);
+  --color-positive: #00b894;
+  --color-neutral: #f59e0b;
+  --color-negative: #ef4444;
+}
+
+[data-theme='dark'] {
+  color-scheme: dark;
+  --color-surface: #0b1220;
+  --color-surface-subtle: #0f172a;
+  --color-surface-elevated: #131b2f;
+  --color-border: rgba(148, 163, 184, 0.2);
+  --color-text: #e2e8f0;
+  --color-text-subtle: #94a3b8;
+  --color-accent: #fb7185;
+  --color-accent-soft: rgba(251, 113, 133, 0.15);
+  --color-positive: #34d399;
+  --color-neutral: #fbbf24;
+  --color-negative: #f87171;
+  --shadow-sm: 0 8px 20px rgba(2, 6, 23, 0.3);
+  --shadow-lg: 0 25px 60px -20px rgba(2, 6, 23, 0.65);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  background: var(--color-surface-subtle);
+  color: var(--color-text);
+  min-height: 100vh;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+img,
+svg {
+  max-width: 100%;
+  display: block;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+p {
+  margin: 0;
+  color: var(--color-text-subtle);
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  background: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  min-height: 100vh;
+}
+
+.shell__sidebar {
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  padding: 32px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 18px;
+  background: var(--color-accent);
+  color: #fff;
+  font-weight: 700;
+  font-size: 20px;
+}
+
+.brand__title {
+  font-weight: 700;
+  font-size: 20px;
+}
+
+.brand__subtitle {
+  font-size: 13px;
+  color: var(--color-text-subtle);
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.nav__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nav__label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-subtle);
+}
+
+.nav__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-subtle);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.nav__item:hover,
+.nav__item:focus {
+  background: rgba(15, 23, 42, 0.05);
+  color: var(--color-text);
+}
+
+[data-theme='dark'] .nav__item:hover,
+[data-theme='dark'] .nav__item:focus {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.nav__item--active {
+  background: var(--color-accent-soft);
+  color: var(--color-text);
+}
+
+.sidebar__footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sidebar__plan {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(255, 77, 77, 0.08), transparent);
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.plan__label {
+  font-size: 12px;
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.plan__score {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.plan__score small {
+  font-size: 13px;
+  color: var(--color-text-subtle);
+}
+
+.plan__description {
+  font-size: 14px;
+}
+
+.shell__content {
+  padding: 36px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.content__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.header__context {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.header__context h1 {
+  font-size: 28px;
+}
+
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.search {
+  position: relative;
+}
+
+.search__input {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 12px 40px 12px 16px;
+  min-width: 260px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search__input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(255, 77, 77, 0.12);
+}
+
+.search__icon {
+  position: absolute;
+  right: 14px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-text-subtle);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: var(--radius-sm);
+  padding: 10px 16px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button--primary {
+  background: var(--color-accent);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.button--primary:hover,
+.button--primary:focus {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
+}
+
+.button--secondary {
+  background: rgba(255, 77, 77, 0.12);
+  color: var(--color-accent);
+  border: 1px solid rgba(255, 77, 77, 0.2);
+}
+
+.button--ghost {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-subtle);
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  color: var(--color-text);
+  border-color: var(--color-text-subtle);
+}
+
+.button--icon {
+  padding: 10px;
+  width: 44px;
+  height: 44px;
+}
+
+.button--floating {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  background: var(--color-accent);
+  color: #fff;
+  width: 64px;
+  height: 64px;
+  border-radius: 22px;
+  box-shadow: var(--shadow-lg);
+  font-size: 28px;
+  z-index: 10;
+}
+
+.user {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+}
+
+.user__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.08);
+  font-weight: 600;
+}
+
+[data-theme='dark'] .user__avatar {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.user__name {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.panel {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.panel--highlight {
+  background: linear-gradient(135deg, rgba(255, 77, 77, 0.12), rgba(255, 255, 255, 0.85));
+  border: none;
+  box-shadow: none;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+}
+
+.panel--cta {
+  align-items: center;
+  justify-content: space-between;
+  flex-direction: row;
+  gap: 24px;
+}
+
+.panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.panel__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.panel__tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--color-text);
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+}
+
+[data-theme='dark'] .tag {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.donut svg {
+  width: 130px;
+  height: 130px;
+}
+
+.donut__track {
+  fill: none;
+  stroke: rgba(15, 23, 42, 0.08);
+  stroke-width: 2.8;
+}
+
+[data-theme='dark'] .donut__track {
+  stroke: rgba(148, 163, 184, 0.22);
+}
+
+.donut__indicator {
+  fill: none;
+  stroke: var(--color-accent);
+  stroke-width: 2.8;
+  stroke-linecap: round;
+}
+
+.donut__text {
+  fill: var(--color-text);
+  font-size: 0.5em;
+  font-weight: 600;
+  text-anchor: middle;
+}
+
+.grid {
+  display: grid;
+  gap: 24px;
+}
+
+.grid--metrics {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.grid--columns {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.metric {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: var(--shadow-sm);
+}
+
+.metric header {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.metric__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 22px;
+}
+
+[data-theme='dark'] .metric__icon {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.metric__label {
+  font-size: 14px;
+  color: var(--color-text-subtle);
+}
+
+.metric__value {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.metric__trend {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.metric__trend--positive {
+  color: var(--color-positive);
+}
+
+.metric__trend--neutral {
+  color: var(--color-neutral);
+}
+
+.metric__trend--negative {
+  color: var(--color-negative);
+}
+
+.table-responsive {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-subtle);
+}
+
+.table th,
+.table td {
+  padding: 14px 12px;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.table tbody tr {
+  transition: background 0.2s ease;
+}
+
+.table tbody tr:hover {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+[data-theme='dark'] .table tbody tr:hover {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.status--on-track {
+  background: rgba(16, 185, 129, 0.16);
+  color: var(--color-positive);
+}
+
+.status--at-risk {
+  background: rgba(250, 204, 21, 0.22);
+  color: var(--color-neutral);
+}
+
+.status--blocked {
+  background: rgba(248, 113, 113, 0.18);
+  color: var(--color-negative);
+}
+
+.legend {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.legend li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.legend__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.workflow {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.workflow li {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 18px;
+  border-bottom: 1px dashed var(--color-border);
+}
+
+.workflow li:last-child {
+  border-bottom: none;
+}
+
+.workflow__meta {
+  display: flex;
+  gap: 12px;
+  color: var(--color-text-subtle);
+  font-size: 13px;
+}
+
+.insights {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.insight {
+  padding: 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.insight strong {
+  font-size: 16px;
+  color: var(--color-text);
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.timeline li {
+  position: relative;
+  padding-left: 26px;
+}
+
+.timeline li::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 6px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  box-shadow: 0 0 0 6px rgba(255, 77, 77, 0.12);
+}
+
+.timeline__meta {
+  font-size: 12px;
+  color: var(--color-text-subtle);
+}
+
+.portfolio {
+  display: grid;
+  gap: 16px;
+}
+
+.portfolio-card {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.portfolio-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.portfolio-card__badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.06);
+}
+
+[data-theme='dark'] .portfolio-card__badge {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.portfolio-card__trend {
+  font-weight: 600;
+}
+
+.table th[data-sort] {
+  cursor: pointer;
+}
+
+.table th[data-sort]:hover,
+.table th[data-sort]:focus {
+  color: var(--color-text);
+}
+
+.select select,
+.field input,
+.field textarea,
+.field select {
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+  padding: 12px 14px;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field span {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-subtle);
+}
+
+.field-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.field--inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.field input:focus,
+.field textarea:focus,
+.field select:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(255, 77, 77, 0.12);
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+}
+
+.switch input {
+  width: 46px;
+  height: 24px;
+  border-radius: 999px;
+  appearance: none;
+  background: rgba(148, 163, 184, 0.4);
+  position: relative;
+  transition: background 0.2s ease;
+}
+
+.switch input::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  transition: transform 0.2s ease;
+}
+
+.switch input:checked {
+  background: var(--color-accent);
+}
+
+.switch input:checked::after {
+  transform: translateX(22px);
+}
+
+.modal {
+  border: none;
+  padding: 0;
+  border-radius: var(--radius-lg);
+  max-width: 520px;
+  width: calc(100% - 32px);
+  background: transparent;
+}
+
+.modal::backdrop {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.modal__content {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 28px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+}
+
+.modal__header,
+.modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.command-palette {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.45);
+  padding: 24px;
+  z-index: 20;
+}
+
+.command-palette__panel {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  width: min(680px, 100%);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  box-shadow: var(--shadow-lg);
+}
+
+.command-palette__search {
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+}
+
+.command-palette__search:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(255, 77, 77, 0.12);
+}
+
+.command-palette__list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.command-palette__list li button {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-subtle);
+  border: 1px solid transparent;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--color-text);
+}
+
+.command-palette__list li button:hover,
+.command-palette__list li button:focus {
+  border-color: var(--color-accent);
+}
+
+.toast {
+  position: fixed;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: 14px 20px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  z-index: 30;
+}
+
+.toast__icon {
+  font-size: 20px;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-subtle);
+  font-size: 14px;
+}
+
+.footer__links {
+  display: flex;
+  gap: 16px;
+}
+
+@media (max-width: 1200px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .shell__sidebar {
+    position: fixed;
+    inset: 0;
+    max-width: 320px;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 15;
+  }
+
+  .shell__sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  .shell__content {
+    padding: 32px 24px;
+    margin-left: 0;
+  }
+
+  .header__actions {
+    flex-wrap: wrap;
+  }
+
+  .search__input {
+    min-width: 200px;
+  }
+}
+
+@media (max-width: 768px) {
+  .content__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header__actions {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .search__input {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .button--primary,
+  .button--ghost {
+    flex: 1;
+  }
+
+  .panel--highlight {
+    grid-template-columns: 1fr;
+  }
+
+  .panel--cta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .button--floating {
+    bottom: 20px;
+    right: 20px;
+    width: 56px;
+    height: 56px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the empty repo with a modern Menmo Enterprise Suite dashboard experience
- implement responsive layout, command palette, modal workflow, data tables and Chart.js analytics
- add light/dark theming, quick actions and supporting documentation for running the static site

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1a17b326c8331838922f5b532b482