### PR TITLE
Add FastAPI backend and Next.js frontend scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.venv/
+node_modules/
+.next/
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
 # Menmo
+
 menmo.ai
+
+## Backend service
+
+The backend is a FastAPI application with persistence powered by SQLAlchemy. It
+exposes endpoints for managing user profiles, ingesting grants, and returning
+ranked matches.
+
+### Prerequisites
+
+- Python 3.11+
+- (Optional) PostgreSQL 14+ if you do not want to use the default SQLite
+  database.
+
+### Installation
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Running the API locally
+
+```bash
+export DATABASE_URL=sqlite:///./app.db  # or your PostgreSQL connection string
+uvicorn backend.main:app --reload
+```
+
+When running with PostgreSQL ensure the target database already exists. The
+application will create the necessary tables on startup.
+
+### Tests
+
+```bash
+cd backend
+pytest
+```
+
+## Matching logic
+
+`backend/matching.py` implements a lightweight AI-inspired matcher. The module
+embeds user and grant text into sparse vectors and compares them with cosine
+similarity to provide ranked grant recommendations. Unit tests covering the core
+matching behaviour live in `backend/tests/`.
+
+## Frontend client
+
+The frontend is a lightweight Next.js project that consumes the backend API.
+Pages are available for onboarding, browsing grants, and requesting
+recommendations.
+
+### Prerequisites
+
+- Node.js 18+
+- pnpm, npm, or yarn
+
+### Installation and development server
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+By default the client talks to `http://localhost:8000`. To change this set the
+`NEXT_PUBLIC_BACKEND_URL` environment variable before running the dev server.
+
+## Project structure
+
+```
+backend/
+  main.py          # FastAPI application and route definitions
+  db.py            # SQLAlchemy configuration
+  models.py        # ORM models
+  matching.py      # Matching engine
+  tests/           # Pytest test suite
+frontend/
+  src/pages/       # Next.js pages for the Menmo app
+  src/components/  # Shared UI components
+  src/lib/         # API helper utilities
+```

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend service package for Menmo."""

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,39 @@
+"""Database configuration for the Menmo backend service."""
+
+from __future__ import annotations
+
+import os
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+# SQLite requires a special flag to allow the connection to be shared across threads.
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args, future=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Create database tables if they do not exist."""
+    from backend import models  # noqa: WPS433  # ensures model metadata is registered
+
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Generator[Session, None, None]:
+    """Provide a transactional scope around a series of operations."""
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:  # pragma: no cover - defensive rollback
+        db.rollback()
+        raise
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,122 @@
+"""FastAPI entrypoint for the Menmo backend service."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend import matching
+from backend.db import get_db, init_db
+from backend.models import Grant, User
+
+app = FastAPI(title="Menmo Backend", version="0.1.0")
+
+
+class UserBase(BaseModel):
+    name: str
+    email: str
+    organization: str | None = None
+    interests: str
+    goals: str | None = None
+
+
+class UserCreate(UserBase):
+    pass
+
+
+class UserRead(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class GrantBase(BaseModel):
+    title: str
+    description: str
+    focus_area: str | None = None
+    sponsor: str | None = None
+
+
+class GrantCreate(GrantBase):
+    pass
+
+
+class GrantRead(GrantBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class GrantMatch(BaseModel):
+    grant: GrantRead
+    score: float
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+
+@app.post("/users/", response_model=UserRead, status_code=201)
+def create_user(user: UserCreate, db: Session = Depends(get_db)) -> User:
+    existing = db.query(User).filter(User.email == user.email).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="A user with that email already exists.")
+
+    db_user = User(
+        name=user.name,
+        email=user.email,
+        organization=user.organization,
+        interests=user.interests,
+        goals=user.goals,
+    )
+    db.add(db_user)
+    db.flush()
+    db.refresh(db_user)
+    return db_user
+
+
+@app.get("/users/{user_id}", response_model=UserRead)
+def read_user(user_id: int, db: Session = Depends(get_db)) -> User:
+    user = db.get(User, user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@app.post("/grants/", response_model=GrantRead, status_code=201)
+def create_grant(grant: GrantCreate, db: Session = Depends(get_db)) -> Grant:
+    db_grant = Grant(
+        title=grant.title,
+        description=grant.description,
+        focus_area=grant.focus_area,
+        sponsor=grant.sponsor,
+    )
+    db.add(db_grant)
+    db.flush()
+    db.refresh(db_grant)
+    return db_grant
+
+
+@app.get("/grants/", response_model=List[GrantRead])
+def list_grants(db: Session = Depends(get_db)) -> List[Grant]:
+    return db.query(Grant).all()
+
+
+@app.post("/matches/{user_id}", response_model=List[GrantMatch])
+def generate_matches(
+    user_id: int,
+    top_k: int = 5,
+    db: Session = Depends(get_db),
+) -> List[GrantMatch]:
+    try:
+        results = matching.rank_grants_for_user(db, user_id=user_id, top_k=top_k)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return [GrantMatch(grant=GrantRead.from_orm(result.grant), score=result.score) for result in results]

--- a/backend/matching.py
+++ b/backend/matching.py
@@ -1,0 +1,87 @@
+"""Simple AI-inspired matching logic for grants and user profiles."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from sqlalchemy.orm import Session
+
+from backend.models import Grant, User
+
+_TOKEN_PATTERN = re.compile(r"\b\w+\b")
+
+
+@dataclass
+class MatchResult:
+    """Represents a grant match with an associated score."""
+
+    grant: Grant
+    score: float
+
+
+def _tokenize(text: str) -> Iterable[str]:
+    return _TOKEN_PATTERN.findall(text.lower())
+
+
+def embed_text(text: str) -> Counter[str]:
+    """Create a sparse bag-of-words embedding for the supplied text."""
+    return Counter(_tokenize(text))
+
+
+def cosine_similarity(vec_a: Counter[str], vec_b: Counter[str]) -> float:
+    """Compute cosine similarity between two sparse vectors."""
+    dot_product = sum(value * vec_b.get(token, 0) for token, value in vec_a.items())
+    norm_a = math.sqrt(sum(value * value for value in vec_a.values()))
+    norm_b = math.sqrt(sum(value * value for value in vec_b.values()))
+    if not norm_a or not norm_b:
+        return 0.0
+    return dot_product / (norm_a * norm_b)
+
+
+def _user_embedding(user: User) -> Counter[str]:
+    text = " ".join(
+        filter(
+            None,
+            [user.name, user.organization, user.interests, user.goals],
+        )
+    )
+    return embed_text(text)
+
+
+def _grant_embedding(grant: Grant) -> Counter[str]:
+    text = " ".join(
+        filter(
+            None,
+            [grant.title, grant.description, grant.focus_area, grant.sponsor],
+        )
+    )
+    return embed_text(text)
+
+
+def rank_grants_for_user(
+    session: Session,
+    user_id: int,
+    *,
+    top_k: int = 5,
+    min_score: float = 0.0,
+) -> List[MatchResult]:
+    """Rank available grants for a user using cosine similarity."""
+    user = session.get(User, user_id)
+    if user is None:
+        raise ValueError(f"User with id={user_id} was not found.")
+
+    user_vector = _user_embedding(user)
+
+    matches: List[MatchResult] = []
+    for grant in session.query(Grant).all():
+        grant_vector = _grant_embedding(grant)
+        score = cosine_similarity(user_vector, grant_vector)
+        if score >= min_score:
+            matches.append(MatchResult(grant=grant, score=score))
+
+    matches.sort(key=lambda match: match.score, reverse=True)
+    return matches[:top_k]

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,32 @@
+"""Database models for the Menmo backend service."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, Integer, String, Text
+
+from backend.db import Base
+
+
+class User(Base):
+    """A user profile that can receive grant recommendations."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), nullable=False)
+    email = Column(String(255), nullable=False, unique=True, index=True)
+    organization = Column(String(255), nullable=True)
+    interests = Column(Text, nullable=False)
+    goals = Column(Text, nullable=True)
+
+
+class Grant(Base):
+    """A funding opportunity available to users."""
+
+    __tablename__ = "grants"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(255), nullable=False)
+    description = Column(Text, nullable=False)
+    focus_area = Column(String(255), nullable=True)
+    sponsor = Column(String(255), nullable=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+sqlalchemy==2.0.29
+pydantic==1.10.14
+pytest==8.1.1

--- a/backend/tests/test_matching.py
+++ b/backend/tests/test_matching.py
@@ -1,0 +1,76 @@
+"""Tests for the Menmo matching engine."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# Ensure the backend package is importable when running the tests directly.
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from backend.db import Base
+from backend.matching import rank_grants_for_user
+from backend.models import Grant, User
+
+
+def setup_test_session() -> Session:
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, future=True)
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+    Base.metadata.create_all(bind=engine)
+    return TestingSessionLocal()
+
+
+def test_rank_grants_prioritizes_relevant_content() -> None:
+    session = setup_test_session()
+
+    try:
+        user = User(
+            name="Alice",
+            email="alice@example.com",
+            organization="Green Earth",
+            interests="climate change sustainability renewable energy",
+            goals="Expand solar installations across communities",
+        )
+        session.add(user)
+
+        grants = [
+            Grant(
+                title="Community Solar Expansion",
+                description="Funding for renewable energy and solar panel deployment",
+                focus_area="Climate",
+                sponsor="Sunshine Foundation",
+            ),
+            Grant(
+                title="Arts Education Grant",
+                description="Support for arts programs in schools",
+                focus_area="Education",
+                sponsor="Creative Minds",
+            ),
+        ]
+        session.add_all(grants)
+        session.commit()
+
+        matches = rank_grants_for_user(session, user.id, top_k=2)
+
+        assert matches[0].grant.title == "Community Solar Expansion"
+        assert matches[0].score > matches[1].score
+    finally:
+        session.close()
+
+
+def test_rank_grants_handles_missing_user() -> None:
+    session = setup_test_session()
+    try:
+        try:
+            rank_grants_for_user(session, user_id=999)
+        except ValueError as exc:
+            assert "was not found" in str(exc)
+        else:  # pragma: no cover
+            raise AssertionError("Expected ValueError for missing user")
+    finally:
+        session.close()

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone'
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "menmo-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.24",
+    "@types/react": "18.2.59",
+    "@types/react-dom": "18.2.18",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/src/components/GrantMatchList.tsx
+++ b/frontend/src/components/GrantMatchList.tsx
@@ -1,0 +1,28 @@
+import { GrantMatch } from "../lib/api";
+
+interface Props {
+  matches: GrantMatch[];
+}
+
+export function GrantMatchList({ matches }: Props) {
+  if (matches.length === 0) {
+    return <p>No matches yet. Submit your profile to get started!</p>;
+  }
+
+  return (
+    <section>
+      <h2>Recommended Matches</h2>
+      {matches.map((match) => (
+        <article className="card" key={match.grant.id}>
+          <header style={{ marginBottom: "0.5rem" }}>
+            <h3>{match.grant.title}</h3>
+            <small>Score: {(match.score * 100).toFixed(0)}%</small>
+          </header>
+          <p>{match.grant.description}</p>
+          {match.grant.focus_area && <p><strong>Focus:</strong> {match.grant.focus_area}</p>}
+          {match.grant.sponsor && <p><strong>Sponsor:</strong> {match.grant.sponsor}</p>}
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+export function Layout({ children }: Props) {
+  return (
+    <>
+      <header>
+        <h1>Menmo Grants</h1>
+        <nav>
+          <Link href="/">Home</Link>
+          <Link href="/onboarding">Onboarding</Link>
+          <Link href="/grants">Grants</Link>
+          <Link href="/matches">Matches</Link>
+        </nav>
+      </header>
+      <main>{children}</main>
+    </>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,63 @@
+export interface UserPayload {
+  name: string;
+  email: string;
+  organization?: string;
+  interests: string;
+  goals?: string;
+}
+
+export interface GrantPayload {
+  title: string;
+  description: string;
+  focus_area?: string;
+  sponsor?: string;
+}
+
+export interface Grant {
+  id: number;
+  title: string;
+  description: string;
+  focus_area?: string | null;
+  sponsor?: string | null;
+}
+
+export interface GrantMatch {
+  grant: Grant;
+  score: number;
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:8000";
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(detail || `Request failed: ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function createUser(payload: UserPayload) {
+  return request<Grant>("/users/", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export function listGrants() {
+  return request<Grant[]>("/grants/");
+}
+
+export function getMatches(userId: number, topK = 5) {
+  const params = new URLSearchParams({ top_k: topK.toString() });
+  return request<GrantMatch[]>(`/matches/${userId}?${params.toString()}`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,0 +1,7 @@
+import type { AppProps } from "next/app";
+
+import "../styles.css";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/src/pages/grants.tsx
+++ b/frontend/src/pages/grants.tsx
@@ -1,0 +1,27 @@
+import useSWR from "swr";
+
+import { Layout } from "../components/Layout";
+import { Grant, listGrants } from "../lib/api";
+
+export default function GrantsPage() {
+  const { data, error } = useSWR<Grant[]>("/grants", () => listGrants());
+
+  return (
+    <Layout>
+      <section>
+        <h2>Browse Grants</h2>
+        {error && <p>Failed to load grants: {error.message}</p>}
+        {!data && !error && <p>Loading...</p>}
+        {data &&
+          data.map((grant) => (
+            <article className="card" key={grant.id}>
+              <h3>{grant.title}</h3>
+              <p>{grant.description}</p>
+              {grant.focus_area && <p><strong>Focus:</strong> {grant.focus_area}</p>}
+              {grant.sponsor && <p><strong>Sponsor:</strong> {grant.sponsor}</p>}
+            </article>
+          ))}
+      </section>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+import { Layout } from "../components/Layout";
+
+export default function HomePage() {
+  return (
+    <Layout>
+      <section>
+        <h2>Welcome to Menmo</h2>
+        <p>
+          Menmo pairs mission-driven organizations with funding opportunities using
+          lightweight AI matching. Complete onboarding to share your focus areas,
+          browse curated grants, and request personalized recommendations.
+        </p>
+        <Link className="button" href="/onboarding">
+          Get Started
+        </Link>
+      </section>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/matches.tsx
+++ b/frontend/src/pages/matches.tsx
@@ -1,0 +1,57 @@
+import { FormEvent, useState } from "react";
+import useSWR from "swr";
+
+import { Layout } from "../components/Layout";
+import { GrantMatchList } from "../components/GrantMatchList";
+import { getMatches, GrantMatch } from "../lib/api";
+
+export default function MatchesPage() {
+  const [userId, setUserId] = useState<string>("");
+  const [topK, setTopK] = useState<number>(5);
+  const [shouldFetch, setShouldFetch] = useState(false);
+
+  const { data, error, mutate, isLoading } = useSWR<GrantMatch[] | null>(
+    shouldFetch ? ["/matches", userId, topK] : null,
+    () => getMatches(Number(userId), topK)
+  );
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setShouldFetch(true);
+    mutate();
+  }
+
+  return (
+    <Layout>
+      <section>
+        <h2>Get Personalized Matches</h2>
+        <form className="card" onSubmit={handleSubmit}>
+          <label>
+            User ID
+            <input
+              required
+              value={userId}
+              onChange={(event) => setUserId(event.target.value)}
+            />
+          </label>
+          <label>
+            Number of matches
+            <input
+              type="number"
+              min={1}
+              max={20}
+              value={topK}
+              onChange={(event) => setTopK(Number(event.target.value))}
+            />
+          </label>
+          <button className="button" type="submit">
+            Fetch matches
+          </button>
+        </form>
+        {error && <p>Failed to load matches: {error.message}</p>}
+        {isLoading && <p>Loading...</p>}
+        {data && <GrantMatchList matches={data} />}
+      </section>
+    </Layout>
+  );
+}

--- a/frontend/src/pages/onboarding.tsx
+++ b/frontend/src/pages/onboarding.tsx
@@ -1,0 +1,81 @@
+import { FormEvent, useState } from "react";
+
+import { Layout } from "../components/Layout";
+import { createUser, UserPayload } from "../lib/api";
+
+export default function OnboardingPage() {
+  const [form, setForm] = useState<UserPayload>({
+    name: "",
+    email: "",
+    interests: "",
+    organization: "",
+    goals: "",
+  });
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus("Submitting...");
+    try {
+      const user = await createUser(form);
+      setStatus(`Profile saved! User ID: ${user.id}`);
+    } catch (error) {
+      setStatus((error as Error).message);
+    }
+  }
+
+  return (
+    <Layout>
+      <section>
+        <h2>Tell us about your organization</h2>
+        <form className="card" onSubmit={handleSubmit}>
+          <label>
+            Name
+            <input
+              required
+              value={form.name}
+              onChange={(event) => setForm({ ...form, name: event.target.value })}
+            />
+          </label>
+          <label>
+            Email
+            <input
+              required
+              type="email"
+              value={form.email}
+              onChange={(event) => setForm({ ...form, email: event.target.value })}
+            />
+          </label>
+          <label>
+            Organization
+            <input
+              value={form.organization}
+              onChange={(event) => setForm({ ...form, organization: event.target.value })}
+            />
+          </label>
+          <label>
+            Interests
+            <textarea
+              required
+              rows={3}
+              value={form.interests}
+              onChange={(event) => setForm({ ...form, interests: event.target.value })}
+            />
+          </label>
+          <label>
+            Goals
+            <textarea
+              rows={3}
+              value={form.goals}
+              onChange={(event) => setForm({ ...form, goals: event.target.value })}
+            />
+          </label>
+          <button className="button" type="submit">
+            Save profile
+          </button>
+        </form>
+        {status && <p>{status}</p>}
+      </section>
+    </Layout>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,54 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f5f5f5;
+  color: #222;
+}
+
+a {
+  color: inherit;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 2rem;
+}
+
+nav a {
+  margin-right: 1rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+.card {
+  background: white;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background: #2563eb;
+  color: white;
+  font-weight: 600;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create a FastAPI backend with persistence, matching logic, and grant/user endpoints
- implement a lightweight AI-inspired matcher with tests covering ranking behaviour
- scaffold a Next.js frontend with onboarding, grant browsing, and match consumption pages

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d1a4cdb4a88331bae0f358e0610129