### PR TITLE
Add Document Intelligence add-on sample scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
 # Menmo
 menmo.ai
+
+## Azure Document Intelligence add-on samples
+
+The `samples/` folder contains standalone Python scripts that demonstrate how to enable each Azure Document Intelligence add-on. Every script configures a `DocumentIntelligenceClient`, submits an analysis request with the desired feature, and prints the add-on specific section of the response.
+
+### Prerequisites
+
+1. Use Python 3.11 or later.
+2. Install the SDK dependency:
+
+   ```bash
+   python -m pip install azure-ai-documentintelligence
+   ```
+
+3. Export your Document Intelligence resource credentials before running any sample:
+
+   ```bash
+   export DOCUMENTINTELLIGENCE_ENDPOINT="https://<your-resource>.cognitiveservices.azure.com/"
+   export DOCUMENTINTELLIGENCE_KEY="<your-key>"
+   ```
+
+4. Provide either a local file path or a publicly accessible URL for the document you want to analyze.
+
+### Running the samples
+
+Run the commands from the repository root. Each script accepts a document source and an optional `--model-id` argument (defaulting to `prebuilt-layout` unless otherwise noted).
+
+- **Barcodes (`samples/sample_analyze_addon_barcodes.py`)**
+
+  ```bash
+  python samples/sample_analyze_addon_barcodes.py path/to/barcode.pdf
+  ```
+
+  Prints every detected barcode value together with its type, confidence score, and polygon coordinates.
+
+- **Font metadata (`samples/sample_analyze_addon_fonts.py`)**
+
+  ```bash
+  python samples/sample_analyze_addon_fonts.py path/to/document.pdf
+  ```
+
+  Lists the detected font family hints, style/weight details, handwriting detection, and color information for each styled span.
+
+- **Formulas (`samples/sample_analyze_addon_formulas.py`)**
+
+  ```bash
+  python samples/sample_analyze_addon_formulas.py https://contoso.com/math-notes.png
+  ```
+
+  Reports the formulas found on each page, including whether they are inline or block formulas, their confidence, and their bounding polygons.
+
+- **High-resolution bounding boxes (`samples/sample_analyze_addon_highres.py`)**
+
+  ```bash
+  python samples/sample_analyze_addon_highres.py path/to/scan.pdf --max-words 10
+  ```
+
+  Displays the high-resolution polygon for each word (up to the specified limit) so you can visualize the precise OCR coordinates returned by the add-on.
+
+- **Language detection (`samples/sample_analyze_addon_languages.py`)**
+
+  ```bash
+  python samples/sample_analyze_addon_languages.py path/to/multilingual.pdf
+  ```
+
+  Shows the detected language locale, its confidence score, and a sample of the text span associated with each detection.
+
+- **Query fields (`samples/sample_analyze_addon_query_fields.py`)**
+
+  ```bash
+  python samples/sample_analyze_addon_query_fields.py path/to/invoice.pdf --model-id prebuilt-invoice --query "What is the invoice total?" --query "Who is the vendor?"
+  ```
+
+  Executes the supplied natural-language queries and prints the extracted answers, including confidence values and bounding regions. The script provides invoice-related default queries when `--query` arguments are omitted.
+
+Each script raises a clear error if the required environment variables are missing or if the document cannot be loaded. Review the console output to understand how each add-on enriches the base analysis payload.

--- a/samples/common.py
+++ b/samples/common.py
@@ -1,0 +1,148 @@
+"""Helper utilities shared by the Document Intelligence add-on samples."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+from azure.ai.documentintelligence import DocumentIntelligenceClient
+from azure.ai.documentintelligence.models import (
+    AnalyzeDocumentRequest,
+    DocumentField,
+    DocumentSpan,
+)
+from azure.core.credentials import AzureKeyCredential
+
+ENV_ENDPOINT = "DOCUMENTINTELLIGENCE_ENDPOINT"
+ENV_KEY = "DOCUMENTINTELLIGENCE_KEY"
+DEFAULT_MODEL_ID = "prebuilt-layout"
+
+
+def build_client() -> DocumentIntelligenceClient:
+    """Create a :class:`~DocumentIntelligenceClient` using environment variables."""
+    endpoint = os.environ.get(ENV_ENDPOINT)
+    key = os.environ.get(ENV_KEY)
+    if not endpoint or not key:
+        raise RuntimeError(
+            "Set the DOCUMENTINTELLIGENCE_ENDPOINT and DOCUMENTINTELLIGENCE_KEY "
+            "environment variables before running this sample."
+        )
+
+    return DocumentIntelligenceClient(endpoint, AzureKeyCredential(key))
+
+
+def build_analyze_request(source: str) -> AnalyzeDocumentRequest:
+    """Build an :class:`AnalyzeDocumentRequest` for a local file path or URL."""
+    if source.lower().startswith(("http://", "https://")):
+        return AnalyzeDocumentRequest(url_source=source)
+
+    path = Path(source)
+    if not path.is_file():
+        raise FileNotFoundError(f"Could not find document at '{source}'.")
+
+    return AnalyzeDocumentRequest(bytes_source=path.read_bytes())
+
+
+def format_polygon(polygon: Optional[Sequence[float]]) -> str:
+    """Return a readable representation of a polygon."""
+    if not polygon:
+        return "[]"
+
+    points = []
+    for index in range(0, len(polygon), 2):
+        x = polygon[index]
+        y = polygon[index + 1]
+        points.append(f"({x:.2f}, {y:.2f})")
+    return "[" + ", ".join(points) + "]"
+
+
+def get_text_from_spans(content: str, spans: Optional[Iterable[DocumentSpan]]) -> str:
+    """Extract the text covered by the provided spans."""
+    if not content or not spans:
+        return ""
+
+    segments: list[str] = []
+    for span in spans:
+        if span.length:
+            segments.append(content[span.offset : span.offset + span.length])
+    return "".join(segments)
+
+
+def format_field_value(field: DocumentField, *, content: Optional[str] = None) -> str:
+    """Create a readable string representation of a :class:`DocumentField`."""
+    if field is None:
+        return ""
+
+    simple_attrs = (
+        "value_string",
+        "value_date",
+        "value_time",
+        "value_phone_number",
+        "value_number",
+        "value_integer",
+        "value_boolean",
+        "value_country_region",
+    )
+    for attr in simple_attrs:
+        value = getattr(field, attr, None)
+        if value is not None:
+            return str(value)
+
+    if field.type == "currency" and field.value_currency:
+        currency = field.value_currency
+        amount = currency.amount
+        if amount is None:
+            return ""
+        if currency.currency_symbol:
+            return f"{currency.currency_symbol}{amount}"
+        if currency.currency_code:
+            return f"{amount} {currency.currency_code}"
+        return str(amount)
+
+    if field.type == "address" and field.value_address:
+        address = field.value_address
+        components = [
+            address.street_address,
+            address.city,
+            address.state,
+            address.postal_code,
+            address.country_region,
+        ]
+        return ", ".join([component for component in components if component])
+
+    if field.type == "array" and field.value_array:
+        return "[" + ", ".join(format_field_value(item, content=content) for item in field.value_array) + "]"
+
+    if field.type == "object" and field.value_object:
+        return "{ " + ", ".join(
+            f"{name}: {format_field_value(value, content=content)}" for name, value in field.value_object.items()
+        ) + " }"
+
+    if field.type == "selectionMark" and field.value_selection_mark:
+        return field.value_selection_mark
+
+    if field.type == "signature" and field.value_signature:
+        return field.value_signature
+
+    if field.type == "selectionGroup" and field.value_selection_group:
+        return "[" + ", ".join(field.value_selection_group) + "]"
+
+    if field.content:
+        return field.content.strip()
+
+    if content and field.spans:
+        text = get_text_from_spans(content, field.spans).strip()
+        if text:
+            return text
+
+    return ""
+
+
+__all__ = [
+    "DEFAULT_MODEL_ID",
+    "build_analyze_request",
+    "build_client",
+    "format_field_value",
+    "format_polygon",
+    "get_text_from_spans",
+]

--- a/samples/sample_analyze_addon_barcodes.py
+++ b/samples/sample_analyze_addon_barcodes.py
@@ -1,0 +1,64 @@
+"""Sample: analyze a document with the barcodes add-on feature enabled."""
+from __future__ import annotations
+
+import argparse
+
+from azure.ai.documentintelligence.models import DocumentAnalysisFeature
+
+from common import (
+    DEFAULT_MODEL_ID,
+    build_analyze_request,
+    build_client,
+    format_polygon,
+    get_text_from_spans,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze a document and extract barcode values using Azure Document Intelligence."
+    )
+    parser.add_argument("document", help="Path to a local file or a publicly accessible URL to analyze.")
+    parser.add_argument(
+        "--model-id",
+        default=DEFAULT_MODEL_ID,
+        help="Model ID to use (defaults to 'prebuilt-layout').",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    client = build_client()
+    request = build_analyze_request(args.document)
+
+    poller = client.begin_analyze_document(
+        args.model_id,
+        request,
+        features=[DocumentAnalysisFeature.BARCODES],
+    )
+    result = poller.result()
+
+    print(f"Analysis completed with model '{result.model_id}' (API version {result.api_version}).")
+
+    any_barcodes = False
+    for page in result.pages:
+        if not page.barcodes:
+            continue
+
+        any_barcodes = True
+        print(f"\nPage {page.page_number} barcodes (unit: {page.unit or 'unspecified'}):")
+        for index, barcode in enumerate(page.barcodes, start=1):
+            snippet = get_text_from_spans(result.content, [barcode.span]) if barcode.span else ""
+            confidence = f"{barcode.confidence:.2f}" if barcode.confidence is not None else "n/a"
+            print(f"  Barcode #{index} kind={barcode.kind} value='{barcode.value}' confidence={confidence}")
+            if snippet:
+                print(f"    Text span snippet: {snippet}")
+            print(f"    Polygon: {format_polygon(barcode.polygon)}")
+
+    if not any_barcodes:
+        print("\nNo barcodes were detected in the analyzed document.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sample_analyze_addon_fonts.py
+++ b/samples/sample_analyze_addon_fonts.py
@@ -1,0 +1,75 @@
+"""Sample: analyze a document with the font style add-on feature enabled."""
+from __future__ import annotations
+
+import argparse
+
+from azure.ai.documentintelligence.models import DocumentAnalysisFeature
+
+from common import (
+    DEFAULT_MODEL_ID,
+    build_analyze_request,
+    build_client,
+    get_text_from_spans,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze a document and inspect detected font styles using Azure Document Intelligence."
+    )
+    parser.add_argument("document", help="Path to a local file or a publicly accessible URL to analyze.")
+    parser.add_argument(
+        "--model-id",
+        default=DEFAULT_MODEL_ID,
+        help="Model ID to use (defaults to 'prebuilt-layout').",
+    )
+    return parser.parse_args()
+
+
+def describe_style(style, content: str) -> None:
+    text = get_text_from_spans(content, style.spans)
+    print("- Detected style:")
+    print(f"    Similar font family: {style.similar_font_family or 'unknown'}")
+    if style.font_style:
+        print(f"    Font style: {style.font_style}")
+    if style.font_weight:
+        print(f"    Font weight: {style.font_weight}")
+    if style.is_handwritten is None:
+        handwritten = "unknown"
+    else:
+        handwritten = "yes" if style.is_handwritten else "no"
+    print(f"    Handwritten: {handwritten}")
+    if style.color or style.background_color:
+        print(f"    Text color: {style.color or 'n/a'} | Background color: {style.background_color or 'n/a'}")
+    confidence = f"{style.confidence:.2f}" if style.confidence is not None else "n/a"
+    print(f"    Confidence: {confidence}")
+    snippet = text.strip()
+    if snippet:
+        print(f"    Sample text: {snippet}")
+
+
+def main() -> None:
+    args = parse_args()
+    client = build_client()
+    request = build_analyze_request(args.document)
+
+    poller = client.begin_analyze_document(
+        args.model_id,
+        request,
+        features=[DocumentAnalysisFeature.STYLE_FONT],
+    )
+    result = poller.result()
+
+    styles = result.styles or []
+    if not styles:
+        print("No font styles were returned. Ensure the analyzed document contains text.")
+        return
+
+    print(f"Analysis completed with model '{result.model_id}'. {len(styles)} styles detected.\n")
+
+    for style in styles:
+        describe_style(style, result.content)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sample_analyze_addon_formulas.py
+++ b/samples/sample_analyze_addon_formulas.py
@@ -1,0 +1,64 @@
+"""Sample: analyze a document with the formulas add-on feature enabled."""
+from __future__ import annotations
+
+import argparse
+
+from azure.ai.documentintelligence.models import DocumentAnalysisFeature
+
+from common import (
+    DEFAULT_MODEL_ID,
+    build_analyze_request,
+    build_client,
+    format_polygon,
+    get_text_from_spans,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze a document and list detected mathematical formulas."
+    )
+    parser.add_argument("document", help="Path to a local file or a publicly accessible URL to analyze.")
+    parser.add_argument(
+        "--model-id",
+        default=DEFAULT_MODEL_ID,
+        help="Model ID to use (defaults to 'prebuilt-layout').",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    client = build_client()
+    request = build_analyze_request(args.document)
+
+    poller = client.begin_analyze_document(
+        args.model_id,
+        request,
+        features=[DocumentAnalysisFeature.FORMULAS],
+    )
+    result = poller.result()
+
+    print(f"Analysis completed with model '{result.model_id}' (API version {result.api_version}).")
+
+    found_any = False
+    for page in result.pages:
+        if not page.formulas:
+            continue
+
+        found_any = True
+        print(f"\nPage {page.page_number} formulas:")
+        for index, formula in enumerate(page.formulas, start=1):
+            snippet = get_text_from_spans(result.content, [formula.span]) if formula.span else ""
+            confidence = f"{formula.confidence:.2f}" if formula.confidence is not None else "n/a"
+            print(f"  Formula #{index} kind={formula.kind} value='{formula.value}' confidence={confidence}")
+            if snippet:
+                print(f"    Text span snippet: {snippet}")
+            print(f"    Polygon: {format_polygon(formula.polygon)}")
+
+    if not found_any:
+        print("\nNo formulas were detected in the analyzed document.")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sample_analyze_addon_highres.py
+++ b/samples/sample_analyze_addon_highres.py
@@ -1,0 +1,67 @@
+"""Sample: analyze a document with the high-resolution OCR add-on feature enabled."""
+from __future__ import annotations
+
+import argparse
+
+from azure.ai.documentintelligence.models import DocumentAnalysisFeature
+
+from common import (
+    DEFAULT_MODEL_ID,
+    build_analyze_request,
+    build_client,
+    format_polygon,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze a document and display high-resolution word bounding boxes."
+    )
+    parser.add_argument("document", help="Path to a local file or a publicly accessible URL to analyze.")
+    parser.add_argument(
+        "--model-id",
+        default=DEFAULT_MODEL_ID,
+        help="Model ID to use (defaults to 'prebuilt-layout').",
+    )
+    parser.add_argument(
+        "--max-words",
+        type=int,
+        default=20,
+        help="Maximum number of word bounding boxes to print per page (default: 20).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    client = build_client()
+    request = build_analyze_request(args.document)
+
+    poller = client.begin_analyze_document(
+        args.model_id,
+        request,
+        features=[DocumentAnalysisFeature.OCR_HIGH_RESOLUTION],
+    )
+    result = poller.result()
+
+    print(f"Analysis completed with model '{result.model_id}' (API version {result.api_version}).")
+
+    for page in result.pages:
+        words = page.words or []
+        if not words:
+            print(f"\nPage {page.page_number} did not return any words.")
+            continue
+
+        print(
+            f"\nPage {page.page_number} - size: {page.width}x{page.height} {page.unit or ''} | displaying up to {args.max_words} words"
+        )
+        for word in words[: args.max_words]:
+            confidence = f"{word.confidence:.2f}" if word.confidence is not None else "n/a"
+            print(f"  '{word.content}' -> {format_polygon(word.polygon)} (confidence {confidence})")
+
+        if len(words) > args.max_words:
+            print(f"  ... {len(words) - args.max_words} additional words omitted for brevity ...")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sample_analyze_addon_languages.py
+++ b/samples/sample_analyze_addon_languages.py
@@ -1,0 +1,57 @@
+"""Sample: analyze a document with the language detection add-on feature enabled."""
+from __future__ import annotations
+
+import argparse
+
+from azure.ai.documentintelligence.models import DocumentAnalysisFeature
+
+from common import (
+    DEFAULT_MODEL_ID,
+    build_analyze_request,
+    build_client,
+    get_text_from_spans,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze a document and print detected languages with confidence scores."
+    )
+    parser.add_argument("document", help="Path to a local file or a publicly accessible URL to analyze.")
+    parser.add_argument(
+        "--model-id",
+        default=DEFAULT_MODEL_ID,
+        help="Model ID to use (defaults to 'prebuilt-layout').",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    client = build_client()
+    request = build_analyze_request(args.document)
+
+    poller = client.begin_analyze_document(
+        args.model_id,
+        request,
+        features=[DocumentAnalysisFeature.LANGUAGES],
+    )
+    result = poller.result()
+
+    languages = result.languages or []
+    if not languages:
+        print("No languages were detected. Provide a document that contains textual content.")
+        return
+
+    print(f"Analysis completed with model '{result.model_id}'. {len(languages)} language spans detected.\n")
+
+    for language in languages:
+        snippet = get_text_from_spans(result.content, language.spans)
+        confidence = f"{language.confidence:.2f}" if language.confidence is not None else "n/a"
+        print(f"Locale: {language.locale} | Confidence: {confidence}")
+        if snippet:
+            print(f"  Sample text: {snippet.strip()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sample_analyze_addon_query_fields.py
+++ b/samples/sample_analyze_addon_query_fields.py
@@ -1,0 +1,96 @@
+"""Sample: analyze a document with the query fields add-on feature enabled."""
+from __future__ import annotations
+
+import argparse
+
+from azure.ai.documentintelligence.models import DocumentAnalysisFeature
+
+from common import (
+    DEFAULT_MODEL_ID,
+    build_analyze_request,
+    build_client,
+    format_field_value,
+    format_polygon,
+)
+
+
+DEFAULT_QUERIES = [
+    "What is the invoice number?",
+    "What is the invoice date?",
+    "What is the total amount due?",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze a document using query fields and print the extracted answers."
+    )
+    parser.add_argument("document", help="Path to a local file or a publicly accessible URL to analyze.")
+    parser.add_argument(
+        "--model-id",
+        default=DEFAULT_MODEL_ID,
+        help="Model ID to use (defaults to 'prebuilt-layout').",
+    )
+    parser.add_argument(
+        "--query",
+        dest="queries",
+        action="append",
+        help="Query to ask the document. Specify multiple --query arguments to run several queries.",
+    )
+    return parser.parse_args()
+
+
+def describe_fields(result, document) -> None:
+    if not document.fields:
+        print("  No fields were returned for this document.")
+        return
+
+    for name, field in document.fields.items():
+        value = format_field_value(field, content=result.content)
+        confidence = f"{field.confidence:.2f}" if field.confidence is not None else "n/a"
+        print(f"  {name}: {value} (type={field.type}, confidence={confidence})")
+        if field.bounding_regions:
+            for region in field.bounding_regions:
+                print(
+                    "    "
+                    + f"Page {region.page_number} location: {format_polygon(region.polygon)}"
+                )
+
+
+def main() -> None:
+    args = parse_args()
+    queries = args.queries or DEFAULT_QUERIES
+
+    client = build_client()
+    request = build_analyze_request(args.document)
+
+    poller = client.begin_analyze_document(
+        args.model_id,
+        request,
+        features=[DocumentAnalysisFeature.QUERY_FIELDS],
+        query_fields=queries,
+    )
+    result = poller.result()
+
+    if not result.documents:
+        print("No document-level fields were returned. Try a model that supports query fields, such as prebuilt-invoice.")
+        return
+
+    print(
+        f"Analysis completed with model '{result.model_id}'. "
+        f"Received {len(result.documents)} document(s) containing query answers.\n"
+    )
+
+    for index, document in enumerate(result.documents, start=1):
+        confidence = f"{document.confidence:.2f}" if document.confidence is not None else "n/a"
+        print(f"Document #{index} type={document.doc_type} confidence={confidence}")
+        describe_fields(result, document)
+        print()
+
+    print("Queries executed:")
+    for query in queries:
+        print(f"  - {query}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a shared helper module for the Document Intelligence add-on samples
- create sample scripts covering barcode, font, formula, high-resolution, language, and query-field features
- document prerequisites and usage instructions for running the new samples

## Testing
- python -m compileall samples

------
https://chatgpt.com/codex/tasks/task_e_68d1b378c534833183644afa0a0c6b96