### PR TITLE
Add Document Intelligence sample scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,96 @@
 # Menmo
+
 menmo.ai
+
+## Document Intelligence samples
+
+The `samples/` folder contains command line utilities that demonstrate how to call
+Azure Document Intelligence prebuilt models for invoices, identity documents,
+receipts, and US W-2 tax forms. Each script accepts either a local file path or an
+HTTPS/SAS URL via the `--document` argument and prints the most important fields in a
+readable format.
+
+### Prerequisites
+
+* Python 3.8 or later.
+* Install the SDK dependency:
+
+  ```bash
+  pip install azure-ai-documentintelligence
+  ```
+
+* An Azure Document Intelligence resource endpoint and API key.
+
+Each command accepts optional `--locale` and `--pages` parameters so you can control
+language hints and the page range submitted to the service.
+
+### Invoice analysis
+
+Analyze a local invoice:
+
+```bash
+python samples/sample_analyze_invoices.py \
+  --endpoint https://<resource>.cognitiveservices.azure.com \
+  --key <api-key> \
+  --document ./invoices/contoso-invoice.pdf \
+  --locale en-US
+```
+
+Analyze an invoice stored behind a SAS URL:
+
+```bash
+python samples/sample_analyze_invoices.py \
+  --endpoint https://<resource>.cognitiveservices.azure.com \
+  --key <api-key> \
+  --document "https://storageaccount.blob.core.windows.net/documents/invoice.pdf?<sas-token>"
+```
+
+### Identity document analysis
+
+```bash
+python samples/sample_analyze_identity_documents.py \
+  --endpoint https://<resource>.cognitiveservices.azure.com \
+  --key <api-key> \
+  --document ./ids/license.jpg
+```
+
+```bash
+python samples/sample_analyze_identity_documents.py \
+  --endpoint https://<resource>.cognitiveservices.azure.com \
+  --key <api-key> \
+  --document "https://storageaccount.blob.core.windows.net/ids/passport.png?<sas-token>"
+```
+
+### Receipt analysis
+
+```bash
+python samples/sample_analyze_receipts.py \
+  --endpoint https://<resource>.cognitiveservices.azure.com \
+  --key <api-key> \
+  --document ./receipts/contoso-allinone.jpg
+```
+
+```bash
+python samples/sample_analyze_receipts.py \
+  --endpoint https://<resource>.cognitiveservices.azure.com \
+  --key <api-key> \
+  --document "https://storageaccount.blob.core.windows.net/receipts/store-receipt.jpg?<sas-token>"
+```
+
+### US W-2 tax form analysis
+
+```bash
+python samples/sample_analyze_tax_us_w2.py \
+  --endpoint https://<resource>.cognitiveservices.azure.com \
+  --key <api-key> \
+  --document ./taxforms/sample_w2.png \
+  --locale en-US
+```
+
+```bash
+python samples/sample_analyze_tax_us_w2.py \
+  --endpoint https://<resource>.cognitiveservices.azure.com \
+  --key <api-key> \
+  --document "https://storageaccount.blob.core.windows.net/tax/w2.png?<sas-token>" \
+  --locale en-US
+```

--- a/samples/_helpers.py
+++ b/samples/_helpers.py
@@ -1,0 +1,185 @@
+"""Shared helpers for Document Intelligence samples."""
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Any, Callable, Dict, List, MutableMapping, Optional, Tuple
+from urllib.parse import urlparse
+
+from azure.ai.documentintelligence import DocumentIntelligenceClient
+from azure.ai.documentintelligence.models import (
+    AddressValue,
+    AnalyzeDocumentRequest,
+    CurrencyValue,
+    DocumentField,
+)
+from azure.core.credentials import AzureKeyCredential
+
+
+def add_common_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Add standard CLI arguments used by the Document Intelligence samples."""
+    parser.add_argument(
+        "--endpoint",
+        required=True,
+        help="Document Intelligence endpoint, e.g. https://<resource-name>.cognitiveservices.azure.com.",
+    )
+    parser.add_argument("--key", required=True, help="Document Intelligence API key.")
+    parser.add_argument(
+        "--document",
+        required=True,
+        help="Path to a local document or an HTTPS/SAS URL that should be analyzed.",
+    )
+    parser.add_argument(
+        "--locale",
+        help="Optional BCP-47 language code that hints the document language (for example: en-US).",
+    )
+    parser.add_argument(
+        "--pages",
+        help="Optional comma separated list of 1-indexed pages or page ranges (for example: 1,3-5).",
+    )
+    return parser
+
+
+def create_client(endpoint: str, key: str) -> DocumentIntelligenceClient:
+    """Create a :class:`DocumentIntelligenceClient` from endpoint and key credentials."""
+    return DocumentIntelligenceClient(endpoint=endpoint, credential=AzureKeyCredential(key))
+
+
+def _is_url(document: str) -> bool:
+    parsed = urlparse(document)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _build_analyze_request(document: str) -> AnalyzeDocumentRequest:
+    expanded = os.path.expanduser(document)
+    file_path = Path(expanded)
+    if file_path.is_file():
+        data = file_path.read_bytes()
+        if not data:
+            raise ValueError(f"The document at '{file_path}' is empty.")
+        return AnalyzeDocumentRequest(bytes_source=data)
+    if _is_url(document):
+        return AnalyzeDocumentRequest(url_source=document)
+    raise FileNotFoundError(
+        "Document source must be an existing file or an HTTPS/SAS URL. "
+        f"Could not resolve '{document}'."
+    )
+
+
+def analyze_document(
+    client: DocumentIntelligenceClient,
+    model_id: str,
+    document: str,
+    *,
+    locale: Optional[str] = None,
+    pages: Optional[str] = None,
+) -> MutableMapping[str, Any]:
+    """Start an analysis operation and return the result."""
+    request = _build_analyze_request(document)
+    kwargs: Dict[str, Any] = {}
+    if locale:
+        kwargs["locale"] = locale
+    if pages:
+        kwargs["pages"] = pages
+    poller = client.begin_analyze_document(model_id=model_id, body=request, **kwargs)
+    return poller.result()
+
+
+def format_currency_value(currency: CurrencyValue) -> str:
+    amount = currency.amount
+    amount_text = f"{amount:,.2f}" if amount is not None else ""
+    if currency.currency_code:
+        if amount_text:
+            return f"{amount_text} {currency.currency_code}"
+        return currency.currency_code
+    if currency.currency_symbol:
+        return f"{currency.currency_symbol}{amount_text}" if amount_text else currency.currency_symbol
+    return amount_text
+
+
+def format_address_value(address: AddressValue) -> str:
+    lines: List[str] = []
+    if address.street_address:
+        lines.append(address.street_address)
+    line_two_parts = [part for part in (address.city, address.state, address.postal_code) if part]
+    if line_two_parts:
+        lines.append(", ".join(line_two_parts))
+    if address.country_region:
+        lines.append(address.country_region)
+    if not lines:
+        components = [
+            part
+            for part in (
+                address.house_number,
+                address.road,
+                address.city,
+                address.state,
+                address.postal_code,
+                address.country_region,
+            )
+            if part
+        ]
+        if components:
+            lines.append(", ".join(components))
+    return "; ".join(lines)
+
+
+def format_document_field(field: Optional[DocumentField]) -> Optional[Any]:
+    if field is None:
+        return None
+    if field.value_currency is not None:
+        return format_currency_value(field.value_currency)
+    if field.value_address is not None:
+        return format_address_value(field.value_address)
+    if field.value_date is not None:
+        return field.value_date.isoformat()
+    if field.value_time is not None:
+        return field.value_time.isoformat()
+    if field.value_phone_number is not None:
+        return field.value_phone_number
+    if field.value_country_region is not None:
+        return field.value_country_region
+    if field.value_string is not None:
+        return field.value_string
+    if field.value_integer is not None:
+        return field.value_integer
+    if field.value_number is not None:
+        return field.value_number
+    if field.value_boolean is not None:
+        return field.value_boolean
+    if field.value_object is not None:
+        return {key: format_document_field(value) for key, value in field.value_object.items()}
+    if field.value_array is not None:
+        return [format_document_field(item) for item in field.value_array]
+    if field.content:
+        return field.content.strip()
+    return None
+
+
+def confidence_to_str(field: Optional[DocumentField]) -> Optional[str]:
+    if field is not None and field.confidence is not None:
+        return f"{field.confidence:.2f}"
+    return None
+
+
+def value_with_confidence(
+    field: Optional[DocumentField],
+    formatter: Optional[Callable[[DocumentField], Any]] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Return a formatted value string and confidence for a document field."""
+    if field is None:
+        return None, None
+    if formatter is not None:
+        value = formatter(field)
+    else:
+        value = format_document_field(field)
+        if field.value_currency is None and field.value_number is not None:
+            value = f"{field.value_number:,.2f}"
+        elif field.value_integer is not None:
+            value = str(field.value_integer)
+        elif isinstance(value, bool):
+            value = "Yes" if value else "No"
+    if value is not None and not isinstance(value, str):
+        value = str(value)
+    return value, confidence_to_str(field)

--- a/samples/sample_analyze_identity_documents.py
+++ b/samples/sample_analyze_identity_documents.py
@@ -1,0 +1,77 @@
+"""Analyze identity documents with the prebuilt model."""
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+from azure.ai.documentintelligence.models import AnalyzedDocument, DocumentField
+
+from _helpers import (
+    add_common_arguments,
+    analyze_document,
+    create_client,
+    value_with_confidence,
+)
+
+MODEL_ID = "prebuilt-idDocument"
+
+
+def print_field(label: str, field: Optional[DocumentField], indent: int = 4) -> None:
+    value, confidence = value_with_confidence(field)
+    prefix = " " * indent + f"{label}: "
+    if value is None or value == "":
+        print(prefix + "--")
+        return
+    text = value
+    if confidence:
+        text += f" (confidence: {confidence})"
+    print(prefix + text)
+
+
+def describe_identity_document(document: AnalyzedDocument, index: int) -> None:
+    print(f"-------- Identity document #{index} ({document.doc_type or 'idDocument'}) --------")
+    fields = document.fields or {}
+    print("  Person details")
+    print_field("First name", fields.get("FirstName"))
+    print_field("Last name", fields.get("LastName"))
+    print_field("Full name", fields.get("FullName"))
+    print_field("Sex", fields.get("Sex"))
+    print_field("Date of birth", fields.get("DateOfBirth"))
+    print_field("Date of expiration", fields.get("DateOfExpiration"))
+    print_field("Date of issue", fields.get("DateOfIssue"))
+    print("  Document information")
+    print_field("Document number", fields.get("DocumentNumber"))
+    print_field("Document type", fields.get("DocumentType"))
+    print_field("Country/Region", fields.get("CountryRegion"))
+    print_field("Nationality", fields.get("Nationality"))
+    print_field("Region", fields.get("Region"))
+    print_field("Authority", fields.get("Authority"))
+    print("  Contact details")
+    print_field("Address", fields.get("Address"))
+    print_field("Residence", fields.get("Residence"))
+
+
+def main() -> None:
+    parser = add_common_arguments(argparse.ArgumentParser(description="Analyze identity documents."))
+    args = parser.parse_args()
+
+    client = create_client(args.endpoint, args.key)
+    result = analyze_document(
+        client,
+        MODEL_ID,
+        args.document,
+        locale=args.locale,
+        pages=args.pages,
+    )
+
+    documents = getattr(result, "documents", [])
+    if not documents:
+        print("No identity documents were returned.")
+        return
+
+    for index, analyzed in enumerate(documents, start=1):
+        describe_identity_document(analyzed, index)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sample_analyze_invoices.py
+++ b/samples/sample_analyze_invoices.py
@@ -1,0 +1,153 @@
+"""Analyze invoices with the Document Intelligence prebuilt model."""
+from __future__ import annotations
+
+import argparse
+from typing import Callable, Optional
+
+from azure.ai.documentintelligence.models import AnalyzedDocument, DocumentField
+
+from _helpers import (
+    add_common_arguments,
+    analyze_document,
+    create_client,
+    value_with_confidence,
+)
+
+MODEL_ID = "prebuilt-invoice"
+
+
+def print_field(
+    label: str,
+    field: Optional[DocumentField],
+    indent: int = 4,
+    formatter: Optional[Callable[[DocumentField], str]] = None,
+) -> None:
+    value, confidence = value_with_confidence(field, formatter=formatter)
+    prefix = " " * indent + f"{label}: "
+    if value is None or value == "":
+        print(prefix + "--")
+        return
+    text = value
+    if confidence:
+        text += f" (confidence: {confidence})"
+    print(prefix + text)
+
+
+def print_line_items(items_field: Optional[DocumentField]) -> None:
+    if items_field is None or not items_field.value_array:
+        print("    Line items: --")
+        return
+    print("    Line items:")
+    for index, item in enumerate(items_field.value_array, start=1):
+        item_details = item.value_object or {}
+        description, desc_conf = value_with_confidence(item_details.get("Description"))
+        header = f"      {index}. {description or 'Item'}"
+        if desc_conf:
+            header += f" (confidence: {desc_conf})"
+        print(header)
+        quantity, qty_conf = value_with_confidence(item_details.get("Quantity"))
+        if quantity:
+            line = f"         Quantity: {quantity}"
+            if qty_conf:
+                line += f" (confidence: {qty_conf})"
+            print(line)
+        unit, unit_conf = value_with_confidence(item_details.get("Unit"))
+        if unit:
+            line = f"         Unit: {unit}"
+            if unit_conf:
+                line += f" (confidence: {unit_conf})"
+            print(line)
+        unit_price, unit_price_conf = value_with_confidence(item_details.get("UnitPrice"))
+        if unit_price:
+            line = f"         Unit price: {unit_price}"
+            if unit_price_conf:
+                line += f" (confidence: {unit_price_conf})"
+            print(line)
+        amount, amount_conf = value_with_confidence(item_details.get("Amount"))
+        if amount:
+            line = f"         Line total: {amount}"
+            if amount_conf:
+                line += f" (confidence: {amount_conf})"
+            print(line)
+        tax, tax_conf = value_with_confidence(item_details.get("Tax"))
+        if tax:
+            line = f"         Tax: {tax}"
+            if tax_conf:
+                line += f" (confidence: {tax_conf})"
+            print(line)
+        product_code, product_conf = value_with_confidence(item_details.get("ProductCode"))
+        if product_code:
+            line = f"         Product code: {product_code}"
+            if product_conf:
+                line += f" (confidence: {product_conf})"
+            print(line)
+        item_date, item_date_conf = value_with_confidence(item_details.get("Date"))
+        if item_date:
+            line = f"         Date: {item_date}"
+            if item_date_conf:
+                line += f" (confidence: {item_date_conf})"
+            print(line)
+
+
+def describe_invoice(invoice: AnalyzedDocument, index: int) -> None:
+    print(f"-------- Invoice #{index} ({invoice.doc_type or 'invoice'}) --------")
+    fields = invoice.fields or {}
+    print("  Vendor details")
+    print_field("Name", fields.get("VendorName"))
+    print_field("Address", fields.get("VendorAddress"))
+    print_field("Recipient", fields.get("VendorAddressRecipient"))
+    print_field("Tax ID", fields.get("VendorTaxId"))
+    print_field("Phone", fields.get("VendorPhoneNumber"))
+    print_field("Email", fields.get("VendorEmail"))
+    print("  Customer details")
+    print_field("Name", fields.get("CustomerName"))
+    print_field("ID", fields.get("CustomerId"))
+    print_field("Address", fields.get("CustomerAddress"))
+    print_field("Recipient", fields.get("CustomerAddressRecipient"))
+    print_field("Tax ID", fields.get("CustomerTaxId"))
+    print_field("Billing address", fields.get("BillingAddress"))
+    print_field("Billing recipient", fields.get("BillingAddressRecipient"))
+    print_field("Shipping address", fields.get("ShippingAddress"))
+    print_field("Shipping recipient", fields.get("ShippingAddressRecipient"))
+    print("  Invoice info")
+    print_field("Invoice ID", fields.get("InvoiceId"))
+    print_field("Invoice date", fields.get("InvoiceDate"))
+    print_field("Due date", fields.get("DueDate"))
+    print_field("Purchase order", fields.get("PurchaseOrder"))
+    print_field("Service period start", fields.get("ServiceStartDate"))
+    print_field("Service period end", fields.get("ServiceEndDate"))
+    print_field("Service address", fields.get("ServiceAddress"))
+    print_field("Service recipient", fields.get("ServiceAddressRecipient"))
+    print_line_items(fields.get("Items"))
+    print("  Totals")
+    print_field("Subtotal", fields.get("SubTotal"))
+    print_field("Tax", fields.get("TotalTax"))
+    print_field("Previous balance", fields.get("PreviousUnpaidBalance"))
+    print_field("Amount due", fields.get("AmountDue"))
+    print_field("Invoice total", fields.get("InvoiceTotal"))
+
+
+def main() -> None:
+    parser = add_common_arguments(argparse.ArgumentParser(description="Analyze invoice documents."))
+    args = parser.parse_args()
+
+    client = create_client(args.endpoint, args.key)
+    result = analyze_document(
+        client,
+        MODEL_ID,
+        args.document,
+        locale=args.locale,
+        pages=args.pages,
+    )
+
+    documents = getattr(result, "documents", [])
+    if not documents:
+        print("No invoice documents were returned.")
+        return
+
+    for position, invoice in enumerate(documents, start=1):
+        describe_invoice(invoice, position)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sample_analyze_receipts.py
+++ b/samples/sample_analyze_receipts.py
@@ -1,0 +1,122 @@
+"""Analyze receipts with the Document Intelligence prebuilt model."""
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+from azure.ai.documentintelligence.models import AnalyzedDocument, DocumentField
+
+from _helpers import (
+    add_common_arguments,
+    analyze_document,
+    create_client,
+    value_with_confidence,
+)
+
+MODEL_ID = "prebuilt-receipt"
+
+
+def print_field(label: str, field: Optional[DocumentField], indent: int = 4) -> None:
+    value, confidence = value_with_confidence(field)
+    prefix = " " * indent + f"{label}: "
+    if value is None or value == "":
+        print(prefix + "--")
+        return
+    text = value
+    if confidence:
+        text += f" (confidence: {confidence})"
+    print(prefix + text)
+
+
+def print_line_items(items_field: Optional[DocumentField]) -> None:
+    if items_field is None or not items_field.value_array:
+        print("    Line items: --")
+        return
+    print("    Line items:")
+    for index, item in enumerate(items_field.value_array, start=1):
+        details = item.value_object or {}
+        description, desc_conf = value_with_confidence(details.get("Description"))
+        header = f"      {index}. {description or 'Item'}"
+        if desc_conf:
+            header += f" (confidence: {desc_conf})"
+        print(header)
+        quantity, qty_conf = value_with_confidence(details.get("Quantity"))
+        if quantity:
+            line = f"         Quantity: {quantity}"
+            if qty_conf:
+                line += f" (confidence: {qty_conf})"
+            print(line)
+        price, price_conf = value_with_confidence(details.get("Price"))
+        if price:
+            line = f"         Price: {price}"
+            if price_conf:
+                line += f" (confidence: {price_conf})"
+            print(line)
+        total, total_conf = value_with_confidence(details.get("TotalPrice"))
+        if total:
+            line = f"         Line total: {total}"
+            if total_conf:
+                line += f" (confidence: {total_conf})"
+            print(line)
+        category, category_conf = value_with_confidence(details.get("Category"))
+        if category:
+            line = f"         Category: {category}"
+            if category_conf:
+                line += f" (confidence: {category_conf})"
+            print(line)
+        sku, sku_conf = value_with_confidence(details.get("ProductCode"))
+        if sku:
+            line = f"         Product code: {sku}"
+            if sku_conf:
+                line += f" (confidence: {sku_conf})"
+            print(line)
+
+
+def describe_receipt(receipt: AnalyzedDocument, index: int) -> None:
+    print(f"-------- Receipt #{index} ({receipt.doc_type or 'receipt'}) --------")
+    fields = receipt.fields or {}
+    print("  Merchant details")
+    print_field("Name", fields.get("MerchantName"))
+    print_field("Address", fields.get("MerchantAddress"))
+    print_field("Phone", fields.get("MerchantPhoneNumber"))
+    print_field("Email", fields.get("MerchantEmail"))
+    print_field("Website", fields.get("MerchantWebsite"))
+    print("  Purchase information")
+    print_field("Receipt type", fields.get("ReceiptType"))
+    print_field("Transaction date", fields.get("TransactionDate"))
+    print_field("Transaction time", fields.get("TransactionTime"))
+    print_field("Transaction ID", fields.get("TransactionId"))
+    print_field("Payment method", fields.get("PaymentMethod"))
+    print_field("Tip suggestion", fields.get("TipSuggestions"))
+    print_line_items(fields.get("Items"))
+    print("  Totals")
+    print_field("Subtotal", fields.get("Subtotal"))
+    print_field("Tax", fields.get("TotalTax"))
+    print_field("Tip", fields.get("Tip"))
+    print_field("Total", fields.get("Total"))
+
+
+def main() -> None:
+    parser = add_common_arguments(argparse.ArgumentParser(description="Analyze retail receipts."))
+    args = parser.parse_args()
+
+    client = create_client(args.endpoint, args.key)
+    result = analyze_document(
+        client,
+        MODEL_ID,
+        args.document,
+        locale=args.locale,
+        pages=args.pages,
+    )
+
+    documents = getattr(result, "documents", [])
+    if not documents:
+        print("No receipt documents were returned.")
+        return
+
+    for index, receipt in enumerate(documents, start=1):
+        describe_receipt(receipt, index)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/sample_analyze_tax_us_w2.py
+++ b/samples/sample_analyze_tax_us_w2.py
@@ -1,0 +1,127 @@
+"""Analyze US W-2 tax forms with the Document Intelligence prebuilt model."""
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+from azure.ai.documentintelligence.models import AnalyzedDocument, DocumentField
+
+from _helpers import (
+    add_common_arguments,
+    analyze_document,
+    create_client,
+    value_with_confidence,
+)
+
+MODEL_ID = "prebuilt-tax.us.w2"
+
+
+def print_field(label: str, field: Optional[DocumentField], indent: int = 4) -> None:
+    value, confidence = value_with_confidence(field)
+    prefix = " " * indent + f"{label}: "
+    if value is None or value == "":
+        print(prefix + "--")
+        return
+    text = value
+    if confidence:
+        text += f" (confidence: {confidence})"
+    print(prefix + text)
+
+
+def describe_party(label: str, party_field: Optional[DocumentField]) -> None:
+    print(f"  {label}")
+    if party_field is None or not party_field.value_object:
+        print("    --")
+        return
+    details = party_field.value_object
+    print_field("Name", details.get("Name"))
+    id_field = details.get("IdNumber")
+    if id_field is not None:
+        print_field("ID", id_field)
+    ssn_field = details.get("SocialSecurityNumber")
+    if ssn_field is not None:
+        print_field("SSN", ssn_field)
+    print_field("Address", details.get("Address"))
+
+
+def describe_additional_info(additional_field: Optional[DocumentField]) -> None:
+    print("  Additional information")
+    if additional_field is None or not additional_field.value_array:
+        print("    --")
+        return
+    for entry in additional_field.value_array:
+        data = entry.value_object or {}
+        letter, letter_conf = value_with_confidence(data.get("LetterCode"))
+        amount, amount_conf = value_with_confidence(data.get("Amount"))
+        parts = []
+        if letter:
+            part = f"Code {letter}"
+            if letter_conf:
+                part += f" (confidence: {letter_conf})"
+            parts.append(part)
+        if amount:
+            part = f"Amount {amount}"
+            if amount_conf:
+                part += f" (confidence: {amount_conf})"
+            parts.append(part)
+        if parts:
+            print("    - " + "; ".join(parts))
+
+
+def describe_w2(document: AnalyzedDocument, index: int) -> None:
+    print(f"-------- W-2 #{index} ({document.doc_type or 'tax.us.w2'}) --------")
+    fields = document.fields or {}
+    print_field("Form variant", fields.get("W2FormVariant"))
+    print_field("Tax year", fields.get("TaxYear"))
+    print_field("Form copy", fields.get("W2Copy"))
+    print_field("Control number", fields.get("ControlNumber"))
+    describe_party("Employee", fields.get("Employee"))
+    describe_party("Employer", fields.get("Employer"))
+    print("  Income and taxes")
+    print_field("Wages, tips, other compensation", fields.get("WagesTipsAndOtherCompensation"))
+    print_field("Federal income tax withheld", fields.get("FederalIncomeTaxWithheld"))
+    print_field("Social Security wages", fields.get("SocialSecurityWages"))
+    print_field("Social Security tax withheld", fields.get("SocialSecurityTaxWithheld"))
+    print_field("Social Security tips", fields.get("SocialSecurityTips"))
+    print_field("Medicare wages and tips", fields.get("MedicareWagesAndTips"))
+    print_field("Medicare tax withheld", fields.get("MedicareTaxWithheld"))
+    print_field("Allocated tips", fields.get("AllocatedTips"))
+    print_field("Dependent care benefits", fields.get("DependentCareBenefits"))
+    print_field("Non-qualified plans", fields.get("NonQualifiedPlans"))
+    print_field("Verification code", fields.get("VerificationCode"))
+    print_field("State wages, tips, etc.", fields.get("StateWagesTipsEtc"))
+    print_field("State income tax", fields.get("StateIncomeTax"))
+    print_field("Local wages, tips, etc.", fields.get("LocalWagesTipsEtc"))
+    print_field("Local income tax", fields.get("LocalIncomeTax"))
+    describe_additional_info(fields.get("AdditionalInfo"))
+    print("  Flags")
+    print_field("Statutory employee", fields.get("IsStatutoryEmployee"))
+    print_field("Retirement plan", fields.get("IsRetirementPlan"))
+    print_field("Third-party sick pay", fields.get("IsThirdPartySickPay"))
+    print_field("Other notes", fields.get("Other"))
+
+
+def main() -> None:
+    parser = add_common_arguments(argparse.ArgumentParser(description="Analyze US W-2 tax forms."))
+    args = parser.parse_args()
+
+    client = create_client(args.endpoint, args.key)
+    result = analyze_document(
+        client,
+        MODEL_ID,
+        args.document,
+        locale=args.locale,
+        pages=args.pages,
+    )
+
+    documents = getattr(result, "documents", [])
+    if not documents:
+        print("No W-2 documents were returned.")
+        return
+
+    for index, document in enumerate(documents, start=1):
+        describe_w2(document, index)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a shared helper module for Document Intelligence sample scripts
- add CLI utilities for invoice, identity document, receipt, and W-2 analysis that print key fields
- document how to run each sample against local files or SAS URLs in the README

## Testing
- python -m compileall samples

------
https://chatgpt.com/codex/tasks/task_e_68d1b374574083318794bc6fefebb518