### PR TITLE
Add frontend journey flows and matches endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -353,6 +353,23 @@ def funding_match(
 
 
 # ---------------------------------------------------------------------------
+# Matches – surfaced for the frontend dashboard
+# ---------------------------------------------------------------------------
+@app.get("/matches/{user_id}", response_model=List[MatchResponse])
+def list_matches(user_id: int, session: Session = Depends(get_session)) -> List[MatchResponse]:
+    """Return stored matches for a user ordered by score."""
+
+    _get_user(session, user_id)
+    matches = (
+        session.query(Match)
+        .filter(Match.user_id == user_id)
+        .order_by(Match.score.desc())
+        .all()
+    )
+    return [MatchResponse.model_validate(match) for match in matches]
+
+
+# ---------------------------------------------------------------------------
 # Stage 3 – Gap-to-Yes planner
 # ---------------------------------------------------------------------------
 @app.post("/journey/gap-plan", response_model=List[TaskRead])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link, Route, Routes } from 'react-router-dom';
 
 import GrantSearchPage from './pages/GrantSearchPage';
@@ -6,7 +6,29 @@ import MatchesPage from './pages/MatchesPage';
 import OnboardingPage from './pages/OnboardingPage';
 
 const App: React.FC = () => {
-  const [userId, setUserId] = useState<number | null>(null);
+  const [userId, setUserId] = useState<number | null>(() => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+    const stored = window.localStorage.getItem('menmo:user-id');
+    return stored ? Number(stored) : null;
+  });
+
+  useEffect(() => {
+    if (userId) {
+      window.localStorage.setItem('menmo:user-id', String(userId));
+    }
+  }, [userId]);
+
+  const handleProfileCreated = useCallback((id: number) => {
+    setUserId(id);
+    window.localStorage.setItem('menmo:user-id', String(id));
+  }, []);
+
+  const handleResetProfile = useCallback(() => {
+    setUserId(null);
+    window.localStorage.removeItem('menmo:user-id');
+  }, []);
 
   return (
     <div className="app-container">
@@ -17,10 +39,18 @@ const App: React.FC = () => {
           <Link to="/grants">Grant search</Link>
           <Link to="/matches">Recommended matches</Link>
         </nav>
+        {userId && (
+          <button type="button" className="link-button" onClick={handleResetProfile}>
+            Reset profile
+          </button>
+        )}
       </header>
       <main>
         <Routes>
-          <Route path="/" element={<OnboardingPage onProfileCreated={setUserId} />} />
+          <Route
+            path="/"
+            element={<OnboardingPage onProfileCreated={handleProfileCreated} userId={userId} />}
+          />
           <Route path="/grants" element={<GrantSearchPage />} />
           <Route path="/matches" element={<MatchesPage userId={userId} />} />
         </Routes>

--- a/frontend/src/components/FundingMatchForm.tsx
+++ b/frontend/src/components/FundingMatchForm.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from 'react';
+
+import { FundingMatchPayload } from '../types';
+
+interface Props {
+  onSubmit: (payload: FundingMatchPayload) => Promise<void>;
+  disabled?: boolean;
+}
+
+type FormState = Omit<FundingMatchPayload, 'capex' | 'opex' | 'co2_reduction' | 'top_k'> & {
+  capex?: number | '';
+  opex?: number | '';
+  co2_reduction?: number | '';
+  top_k?: number | '';
+};
+
+const initialState: FormState = {
+  project_description: '',
+  capex: undefined,
+  opex: undefined,
+  timeline: '',
+  co2_reduction: undefined,
+  partners: '',
+  top_k: 5,
+};
+
+const FundingMatchForm: React.FC<Props> = ({ onSubmit, disabled }) => {
+  const [form, setForm] = useState<FormState>(initialState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value === '' ? undefined : value,
+    }));
+  };
+
+  const handleNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value === '' ? '' : Number(value),
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const payload: FundingMatchPayload = {
+        ...form,
+        timeline: form.timeline?.trim() ? form.timeline : undefined,
+        partners: form.partners?.trim() ? form.partners : undefined,
+        capex: typeof form.capex === 'number' && !Number.isNaN(form.capex) ? form.capex : undefined,
+        opex: typeof form.opex === 'number' && !Number.isNaN(form.opex) ? form.opex : undefined,
+        co2_reduction:
+          typeof form.co2_reduction === 'number' && !Number.isNaN(form.co2_reduction)
+            ? form.co2_reduction
+            : undefined,
+        top_k: typeof form.top_k === 'number' && !Number.isNaN(form.top_k) ? form.top_k : undefined,
+      };
+      await onSubmit(payload);
+    } catch (submitError) {
+      setError('Unable to generate matches.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="funding-match-form">
+      <label>
+        Project description
+        <textarea
+          name="project_description"
+          value={form.project_description ?? ''}
+          onChange={handleTextChange}
+          rows={4}
+          required
+          disabled={disabled}
+        />
+      </label>
+      <div className="form-grid">
+        <label>
+          CapEx (in local currency)
+          <input
+            name="capex"
+            type="number"
+            min={0}
+            step="any"
+            value={form.capex ?? ''}
+            onChange={handleNumberChange}
+            disabled={disabled}
+          />
+        </label>
+        <label>
+          OpEx (annual)
+          <input
+            name="opex"
+            type="number"
+            min={0}
+            step="any"
+            value={form.opex ?? ''}
+            onChange={handleNumberChange}
+            disabled={disabled}
+          />
+        </label>
+        <label>
+          Timeline
+          <input name="timeline" value={form.timeline ?? ''} onChange={handleTextChange} disabled={disabled} />
+        </label>
+        <label>
+          Expected CO₂ reduction (tonnes)
+          <input
+            name="co2_reduction"
+            type="number"
+            min={0}
+            step="any"
+            value={form.co2_reduction ?? ''}
+            onChange={handleNumberChange}
+            disabled={disabled}
+          />
+        </label>
+        <label>
+          Partners
+          <input name="partners" value={form.partners ?? ''} onChange={handleTextChange} disabled={disabled} />
+        </label>
+        <label>
+          Number of matches
+          <input
+            name="top_k"
+            type="number"
+            min={1}
+            max={10}
+            value={form.top_k ?? 5}
+            onChange={handleNumberChange}
+            disabled={disabled}
+          />
+        </label>
+      </div>
+      <button type="submit" disabled={disabled || isSubmitting}>
+        {isSubmitting ? 'Generating...' : 'Generate matches'}
+      </button>
+      {error && <p className="status error">{error}</p>}
+    </form>
+  );
+};
+
+export default FundingMatchForm;

--- a/frontend/src/components/GrantMatchList.tsx
+++ b/frontend/src/components/GrantMatchList.tsx
@@ -19,11 +19,32 @@ const GrantMatchList: React.FC<Props> = ({ matches, isLoading }) => {
   return (
     <ul className="grant-match-list">
       {matches.map((match) => (
-        <li key={match.grant.id} className="grant-match">
+        <li key={match.id} className="grant-match">
           <h3>{match.grant.title}</h3>
           {match.grant.sponsor && <p className="sponsor">Sponsored by {match.grant.sponsor}</p>}
           <p>{match.grant.description}</p>
           <p className="score">Match score: {(match.score * 100).toFixed(1)}%</p>
+          <p className="status">Status: {match.status}</p>
+          {!!match.reasons.length && (
+            <details>
+              <summary>Why this grant fits</summary>
+              <ul>
+                {match.reasons.map((reason, index) => (
+                  <li key={index}>{'text' in reason ? String(reason.text) : JSON.stringify(reason)}</li>
+                ))}
+              </ul>
+            </details>
+          )}
+          {!!match.blockers.length && (
+            <details>
+              <summary>Potential blockers</summary>
+              <ul>
+                {match.blockers.map((blocker, index) => (
+                  <li key={index}>{'text' in blocker ? String(blocker.text) : JSON.stringify(blocker)}</li>
+                ))}
+              </ul>
+            </details>
+          )}
           {match.grant.url && (
             <a href={match.grant.url} target="_blank" rel="noreferrer">
               View grant details

--- a/frontend/src/components/QuickScanForm.tsx
+++ b/frontend/src/components/QuickScanForm.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+
+import { QuickScanPayload } from '../types';
+
+interface Props {
+  onSubmit: (payload: QuickScanPayload) => Promise<void>;
+  disabled?: boolean;
+  initialValues?: QuickScanPayload | null;
+}
+
+const initialState: QuickScanPayload = {
+  industry: '',
+  entity_type: '',
+  location: '',
+  company_size: '',
+  project_type: '',
+  budget_min: undefined,
+  budget_max: undefined,
+};
+
+const QuickScanForm: React.FC<Props> = ({ onSubmit, disabled, initialValues }) => {
+  const baseValues = initialValues ?? {};
+  const [form, setForm] = useState<QuickScanPayload>({ ...initialState, ...baseValues });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  React.useEffect(() => {
+    const defaults = initialValues ?? {};
+    setForm({ ...initialState, ...defaults });
+  }, [initialValues]);
+
+  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value === '' ? undefined : value,
+    }));
+  };
+
+  const handleNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value === '' ? undefined : Number(value),
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await onSubmit(form);
+    } catch (submitError) {
+      setError('Unable to run the quick scan.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="quick-scan-form">
+      <div className="form-grid">
+        <label>
+          Industry
+          <input name="industry" value={form.industry ?? ''} onChange={handleTextChange} disabled={disabled} />
+        </label>
+        <label>
+          Entity type
+          <input name="entity_type" value={form.entity_type ?? ''} onChange={handleTextChange} disabled={disabled} />
+        </label>
+        <label>
+          Location
+          <input name="location" value={form.location ?? ''} onChange={handleTextChange} disabled={disabled} />
+        </label>
+        <label>
+          Company size
+          <input name="company_size" value={form.company_size ?? ''} onChange={handleTextChange} disabled={disabled} />
+        </label>
+        <label>
+          Project type
+          <input name="project_type" value={form.project_type ?? ''} onChange={handleTextChange} disabled={disabled} />
+        </label>
+        <label>
+          Budget minimum
+          <input
+            name="budget_min"
+            type="number"
+            min={0}
+            step="any"
+            value={form.budget_min ?? ''}
+            onChange={handleNumberChange}
+            disabled={disabled}
+          />
+        </label>
+        <label>
+          Budget maximum
+          <input
+            name="budget_max"
+            type="number"
+            min={0}
+            step="any"
+            value={form.budget_max ?? ''}
+            onChange={handleNumberChange}
+            disabled={disabled}
+          />
+        </label>
+      </div>
+      <button type="submit" disabled={disabled || isSubmitting}>
+        {isSubmitting ? 'Scanning...' : 'Run quick scan'}
+      </button>
+      {error && <p className="status error">{error}</p>}
+    </form>
+  );
+};
+
+export default QuickScanForm;

--- a/frontend/src/components/QuickScanResults.tsx
+++ b/frontend/src/components/QuickScanResults.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import { QuickScanResult } from '../types';
+
+interface Props {
+  results: QuickScanResult[];
+  isLoading?: boolean;
+}
+
+const QuickScanResults: React.FC<Props> = ({ results, isLoading }) => {
+  if (isLoading) {
+    return <p>Checking eligibility against stored grants...</p>;
+  }
+
+  if (!results.length) {
+    return <p>No quick scan results yet. Provide profile details and run the scan.</p>;
+  }
+
+  return (
+    <table className="quick-scan-results">
+      <thead>
+        <tr>
+          <th>Grant</th>
+          <th>Status</th>
+          <th>Reasons</th>
+          <th>Blockers</th>
+        </tr>
+      </thead>
+      <tbody>
+        {results.map((item) => (
+          <tr key={item.grant_id}>
+            <td>{item.grant_title}</td>
+            <td>{item.status}</td>
+            <td>
+              <ul>
+                {item.reasons.map((reason, index) => (
+                  <li key={index}>{'text' in reason ? String(reason.text) : JSON.stringify(reason)}</li>
+                ))}
+              </ul>
+            </td>
+            <td>
+              <ul>
+                {item.blockers.map((blocker, index) => (
+                  <li key={index}>{'text' in blocker ? String(blocker.text) : JSON.stringify(blocker)}</li>
+                ))}
+              </ul>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default QuickScanResults;

--- a/frontend/src/components/UserOnboardingForm.tsx
+++ b/frontend/src/components/UserOnboardingForm.tsx
@@ -6,22 +6,45 @@ interface Props {
   onSubmit: (payload: UserProfilePayload) => Promise<void>;
 }
 
-const emptyForm: UserProfilePayload = {
+type FormState = Omit<UserProfilePayload, 'budget_min' | 'budget_max'> & {
+  budget_min?: number | '';
+  budget_max?: number | '';
+};
+
+const initialForm: FormState = {
   name: '',
   email: '',
   organization: '',
   focus_areas: '',
   goals: '',
+  industry: '',
+  entity_type: '',
+  location: '',
+  company_size: '',
+  project_type: '',
+  budget_min: '',
+  budget_max: '',
 };
 
 const UserOnboardingForm: React.FC<Props> = ({ onSubmit }) => {
-  const [form, setForm] = useState<UserProfilePayload>(emptyForm);
+  const [form, setForm] = useState<FormState>(initialForm);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleTextChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = event.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
+    setForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleNumberChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value === '' ? '' : Number(value),
+    }));
   };
 
   const handleSubmit = async (event: React.FormEvent) => {
@@ -30,8 +53,30 @@ const UserOnboardingForm: React.FC<Props> = ({ onSubmit }) => {
     setMessage(null);
 
     try {
-      await onSubmit(form);
+      const payload: UserProfilePayload = {
+        ...form,
+        name: form.name.trim(),
+        email: form.email.trim(),
+        organization: form.organization?.trim() ? form.organization.trim() : undefined,
+        focus_areas: form.focus_areas?.trim() ? form.focus_areas.trim() : undefined,
+        goals: form.goals?.trim() ? form.goals.trim() : undefined,
+        industry: form.industry?.trim() ? form.industry.trim() : undefined,
+        entity_type: form.entity_type?.trim() ? form.entity_type.trim() : undefined,
+        location: form.location?.trim() ? form.location.trim() : undefined,
+        company_size: form.company_size?.trim() ? form.company_size.trim() : undefined,
+        project_type: form.project_type?.trim() ? form.project_type.trim() : undefined,
+        budget_min:
+          typeof form.budget_min === 'number' && !Number.isNaN(form.budget_min)
+            ? form.budget_min
+            : undefined,
+        budget_max:
+          typeof form.budget_max === 'number' && !Number.isNaN(form.budget_max)
+            ? form.budget_max
+            : undefined,
+      };
+      await onSubmit(payload);
       setMessage('Profile saved!');
+      setForm(initialForm);
     } catch (error) {
       setMessage('Unable to save profile. Please try again.');
     } finally {
@@ -43,24 +88,96 @@ const UserOnboardingForm: React.FC<Props> = ({ onSubmit }) => {
     <form onSubmit={handleSubmit} className="onboarding-form">
       <label>
         Name
-        <input name="name" value={form.name} onChange={handleChange} required />
+        <input name="name" value={form.name ?? ''} onChange={handleTextChange} required />
       </label>
       <label>
         Email
-        <input name="email" type="email" value={form.email} onChange={handleChange} required />
+        <input
+          name="email"
+          type="email"
+          value={form.email ?? ''}
+          onChange={handleTextChange}
+          required
+        />
       </label>
       <label>
         Organization
-        <input name="organization" value={form.organization} onChange={handleChange} />
+        <input
+          name="organization"
+          value={form.organization ?? ''}
+          onChange={handleTextChange}
+        />
       </label>
       <label>
         Focus Areas
-        <input name="focus_areas" value={form.focus_areas} onChange={handleChange} />
+        <input
+          name="focus_areas"
+          value={form.focus_areas ?? ''}
+          onChange={handleTextChange}
+        />
       </label>
       <label>
         Goals
-        <textarea name="goals" value={form.goals} onChange={handleChange} rows={4} />
+        <textarea
+          name="goals"
+          value={form.goals ?? ''}
+          onChange={handleTextChange}
+          rows={4}
+        />
       </label>
+      <fieldset>
+        <legend>Eligibility quick scan inputs</legend>
+        <label>
+          Industry
+          <input name="industry" value={form.industry ?? ''} onChange={handleTextChange} />
+        </label>
+        <label>
+          Entity type
+          <input name="entity_type" value={form.entity_type ?? ''} onChange={handleTextChange} />
+        </label>
+        <label>
+          Location
+          <input name="location" value={form.location ?? ''} onChange={handleTextChange} />
+        </label>
+        <label>
+          Company size
+          <input
+            name="company_size"
+            value={form.company_size ?? ''}
+            onChange={handleTextChange}
+          />
+        </label>
+        <label>
+          Project type
+          <input
+            name="project_type"
+            value={form.project_type ?? ''}
+            onChange={handleTextChange}
+          />
+        </label>
+        <label>
+          Budget minimum
+          <input
+            name="budget_min"
+            type="number"
+            min={0}
+            step="any"
+            value={form.budget_min ?? ''}
+            onChange={handleNumberChange}
+          />
+        </label>
+        <label>
+          Budget maximum
+          <input
+            name="budget_max"
+            type="number"
+            min={0}
+            step="any"
+            value={form.budget_max ?? ''}
+            onChange={handleNumberChange}
+          />
+        </label>
+      </fieldset>
       <button type="submit" disabled={isSubmitting}>
         {isSubmitting ? 'Saving...' : 'Save profile'}
       </button>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
+import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/frontend/src/pages/MatchesPage.tsx
+++ b/frontend/src/pages/MatchesPage.tsx
@@ -1,8 +1,17 @@
 import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
+import FundingMatchForm from '../components/FundingMatchForm';
 import GrantMatchList from '../components/GrantMatchList';
-import { MatchResult } from '../types';
+import QuickScanForm from '../components/QuickScanForm';
+import QuickScanResults from '../components/QuickScanResults';
+import {
+  FundingMatchPayload,
+  MatchResult,
+  QuickScanPayload,
+  QuickScanResult,
+  UserProfile,
+} from '../types';
 
 interface Props {
   userId: number | null;
@@ -10,36 +19,160 @@ interface Props {
 
 const MatchesPage: React.FC<Props> = ({ userId }) => {
   const [matches, setMatches] = useState<MatchResult[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [quickScanResults, setQuickScanResults] = useState<QuickScanResult[]>([]);
+  const [isLoadingMatches, setIsLoadingMatches] = useState(false);
+  const [isLoadingQuickScan, setIsLoadingQuickScan] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+
+  const resetStateForUser = useCallback(() => {
+    setMatches([]);
+    setQuickScanResults([]);
+    setMessage(null);
+    setProfile(null);
+  }, []);
+
+  const fetchMatches = useCallback(async () => {
+    if (!userId) {
+      resetStateForUser();
+      return;
+    }
+    setIsLoadingMatches(true);
+    try {
+      const response = await axios.get(`/api/matches/${userId}`);
+      setMatches(response.data);
+    } catch (error) {
+      setMatches([]);
+    } finally {
+      setIsLoadingMatches(false);
+    }
+  }, [resetStateForUser, userId]);
+
+  const fetchProfile = useCallback(async () => {
+    if (!userId) {
+      setProfile(null);
+      return;
+    }
+    try {
+      const response = await axios.get(`/api/users/${userId}`);
+      setProfile(response.data);
+    } catch (error) {
+      setProfile(null);
+    }
+  }, [userId]);
 
   useEffect(() => {
-    const fetchMatches = async () => {
-      if (!userId) {
-        setMatches([]);
-        return;
-      }
-      setIsLoading(true);
-      try {
-        const response = await axios.get(`/api/matches/${userId}`);
-        setMatches(response.data);
-      } catch (error) {
-        setMatches([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
+    if (!userId) {
+      resetStateForUser();
+      return;
+    }
     fetchMatches();
-  }, [userId]);
+    fetchProfile();
+  }, [fetchMatches, fetchProfile, resetStateForUser, userId]);
+
+  const handleQuickScan = async (payload: QuickScanPayload) => {
+    if (!userId) {
+      return;
+    }
+    setIsLoadingQuickScan(true);
+    setMessage(null);
+    try {
+      const response = await axios.post('/api/journey/quick-scan', {
+        ...payload,
+        user_id: userId,
+      });
+      setQuickScanResults(response.data);
+      setMessage('Quick scan completed. Review blockers before moving forward.');
+    } catch (error) {
+      setMessage('Unable to run the quick scan. Please adjust your inputs and try again.');
+    } finally {
+      setIsLoadingQuickScan(false);
+    }
+  };
+
+  const handleFundingMatch = async (payload: FundingMatchPayload) => {
+    if (!userId) {
+      return;
+    }
+    setIsLoadingMatches(true);
+    setMessage(null);
+    try {
+      const response = await axios.post('/api/journey/funding-match', {
+        ...payload,
+        user_id: userId,
+      });
+      setMatches(response.data);
+      setMessage('Matches updated using your latest project profile.');
+    } catch (error) {
+      setMessage('Unable to generate matches. Double-check the project details and try again.');
+    } finally {
+      setIsLoadingMatches(false);
+    }
+  };
 
   if (!userId) {
     return <p>Create a user profile to unlock personalized matches.</p>;
   }
 
   return (
-    <section>
+    <section className="matches-page">
       <h2>Recommended Matches</h2>
-      <GrantMatchList matches={matches} isLoading={isLoading} />
+      <p>
+        Run a quick eligibility scan to understand blockers, then enrich your project brief to
+        generate personalised funding matches.
+      </p>
+      {profile && (
+        <div className="profile-summary">
+          <h4>Active profile</h4>
+          <ul>
+            <li>
+              <strong>Organization:</strong> {profile.organization || '—'}
+            </li>
+            <li>
+              <strong>Industry:</strong> {profile.industry || '—'}
+            </li>
+            <li>
+              <strong>Location:</strong> {profile.location || '—'}
+            </li>
+            <li>
+              <strong>Project type:</strong> {profile.project_type || '—'}
+            </li>
+          </ul>
+        </div>
+      )}
+      {message && <p className="status">{message}</p>}
+
+      <article>
+        <h3>1. Quick eligibility scan</h3>
+        <QuickScanForm
+          onSubmit={handleQuickScan}
+          disabled={isLoadingMatches}
+          initialValues={
+            profile
+              ? {
+                  industry: profile.industry,
+                  entity_type: profile.entity_type,
+                  location: profile.location,
+                  company_size: profile.company_size,
+                  project_type: profile.project_type,
+                  budget_min: profile.budget_min,
+                  budget_max: profile.budget_max,
+                }
+              : null
+          }
+        />
+        <QuickScanResults results={quickScanResults} isLoading={isLoadingQuickScan} />
+      </article>
+
+      <article>
+        <h3>2. Generate funding matches</h3>
+        <FundingMatchForm onSubmit={handleFundingMatch} disabled={isLoadingQuickScan} />
+      </article>
+
+      <article>
+        <h3>3. Review recommendations</h3>
+        <GrantMatchList matches={matches} isLoading={isLoadingMatches} />
+      </article>
     </section>
   );
 };

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -2,13 +2,33 @@ import axios from 'axios';
 import React from 'react';
 
 import UserOnboardingForm from '../components/UserOnboardingForm';
-import { UserProfilePayload } from '../types';
+import { UserProfile, UserProfilePayload } from '../types';
 
 interface Props {
   onProfileCreated: (userId: number) => void;
+  userId?: number | null;
 }
 
-const OnboardingPage: React.FC<Props> = ({ onProfileCreated }) => {
+const OnboardingPage: React.FC<Props> = ({ onProfileCreated, userId }) => {
+  const [existingProfile, setExistingProfile] = React.useState<UserProfile | null>(null);
+
+  React.useEffect(() => {
+    const fetchProfile = async () => {
+      if (!userId) {
+        setExistingProfile(null);
+        return;
+      }
+      try {
+        const response = await axios.get(`/api/users/${userId}`);
+        setExistingProfile(response.data);
+      } catch (error) {
+        setExistingProfile(null);
+      }
+    };
+
+    fetchProfile();
+  }, [userId]);
+
   const handleSubmit = async (payload: UserProfilePayload) => {
     const response = await axios.post('/api/users', payload);
     onProfileCreated(response.data.id);
@@ -18,6 +38,14 @@ const OnboardingPage: React.FC<Props> = ({ onProfileCreated }) => {
     <section>
       <h2>Welcome to Grant Matcher</h2>
       <p>Tell us about your organization to personalize the grants we recommend.</p>
+      {existingProfile && (
+        <aside className="status">
+          <p>
+            You already have a saved profile for <strong>{existingProfile.organization || existingProfile.name}</strong>.
+            Update the details below to create an additional profile or reset from the header to start fresh.
+          </p>
+        </aside>
+      )}
       <UserOnboardingForm onSubmit={handleSubmit} />
     </section>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,194 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+}
+
+.app-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+header nav {
+  display: flex;
+  gap: 1rem;
+}
+
+header nav a {
+  text-decoration: none;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+header nav a:hover {
+  text-decoration: underline;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: #ef4444;
+  cursor: pointer;
+  font-size: 0.95rem;
+  text-decoration: underline;
+}
+
+main section {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+}
+
+form label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+input,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+textarea {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+}
+
+textarea {
+  resize: vertical;
+}
+
+button {
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #4338ca);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.status {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: #e0f2fe;
+  color: #0c4a6e;
+}
+
+.status.error {
+  background: #fee2e2;
+  color: #7f1d1d;
+}
+
+.matches-page article {
+  margin-top: 2rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.quick-scan-results {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.quick-scan-results th,
+.quick-scan-results td {
+  border: 1px solid #e2e8f0;
+  padding: 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.quick-scan-results th {
+  background: #f1f5f9;
+}
+
+.grant-match-list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grant-match {
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(99, 102, 241, 0.08));
+}
+
+.grant-match h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.grant-match .score {
+  font-weight: 600;
+}
+
+.grant-match details {
+  margin-top: 0.5rem;
+}
+
+.profile-summary {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  margin-top: 1rem;
+}
+
+.profile-summary ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+fieldset {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+legend {
+  font-weight: 600;
+  padding: 0 0.5rem;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,17 @@ export interface UserProfilePayload {
   organization?: string;
   focus_areas?: string;
   goals?: string;
+  industry?: string;
+  entity_type?: string;
+  location?: string;
+  company_size?: string;
+  project_type?: string;
+  budget_min?: number;
+  budget_max?: number;
+}
+
+export interface UserProfile extends UserProfilePayload {
+  id: number;
 }
 
 export interface GrantPayload {
@@ -12,9 +23,71 @@ export interface GrantPayload {
   sponsor?: string;
   deadline?: string;
   url?: string;
+  jurisdiction?: string;
+  entity_types?: string[];
+  industries?: string[];
+  project_types?: string[];
+  budget_min?: number;
+  budget_max?: number;
+  min_co2_reduction?: number;
+  max_support?: number;
+  support_unit?: string;
+}
+
+export interface Grant {
+  id: number;
+  title: string;
+  description: string;
+  sponsor?: string | null;
+  deadline?: string | null;
+  url?: string | null;
+  jurisdiction?: string | null;
+  entity_types?: string[] | null;
+  industries?: string[] | null;
+  project_types?: string[] | null;
+  budget_min?: number | null;
+  budget_max?: number | null;
+  min_co2_reduction?: number | null;
+  max_support?: number | null;
+  support_unit?: string | null;
+}
+
+export interface QuickScanPayload {
+  industry?: string;
+  entity_type?: string;
+  location?: string;
+  company_size?: string;
+  project_type?: string;
+  budget_min?: number;
+  budget_max?: number;
+}
+
+export interface QuickScanResult {
+  grant_id: number;
+  grant_title: string;
+  status: string;
+  reasons: Record<string, unknown>[];
+  blockers: Record<string, unknown>[];
+  citations: Record<string, unknown>[];
+}
+
+export interface FundingMatchPayload {
+  project_description: string;
+  capex?: number;
+  opex?: number;
+  timeline?: string;
+  co2_reduction?: number;
+  partners?: string;
+  top_k?: number;
 }
 
 export interface MatchResult {
-  grant: GrantPayload & { id: number };
+  id: number;
+  grant: Grant;
   score: number;
+  status: string;
+  reasons: Record<string, unknown>[];
+  blockers: Record<string, unknown>[];
+  citations: Record<string, unknown>[];
+  insights: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- expose a `/matches/{user_id}` endpoint to return stored recommendations for the dashboard
- persist the selected profile and add quick scan and funding match forms in the React app
- surface rich match explanations with new UI components and styling

## Testing
- npm run build
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e43dd20b308331a395f289773c4b61